### PR TITLE
Fixes #26: Copy bytes instead of using unsafe casting for HID types

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -8,6 +8,11 @@ pub const TYPE_MASK: u8 = 0x80;
 pub const TYPE_INIT: u8 = 0x80;
 pub const TYPE_CONT: u8 = 0x80;
 
+// Size of data chunk expected in U2F Init USB HID Packets
+pub const INIT_DATA_SIZE: usize = HID_RPT_SIZE - 7;
+// Size of data chunk expected in U2F Cont USB HID Packets
+pub const CONT_DATA_SIZE: usize = HID_RPT_SIZE - 5;
+
 pub const PARAMETER_SIZE: usize = 32;
 
 pub const FIDO_USAGE_PAGE: u16 = 0xf1d0; // FIDO alliance HID usage page

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ extern crate boxfnonce;
 
 mod consts;
 mod runloop;
+mod u2ftypes;
 mod u2fprotocol;
 
 mod manager;

--- a/src/linux/device.rs
+++ b/src/linux/device.rs
@@ -8,7 +8,7 @@ use std::os::unix::prelude::*;
 use consts::CID_BROADCAST;
 use platform::hidraw;
 use util::{from_unix_result, to_io_err};
-use u2fprotocol::U2FDevice;
+use u2ftypes::U2FDevice;
 
 #[derive(Debug)]
 pub struct Device {

--- a/src/macos/device.rs
+++ b/src/macos/device.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use consts::HID_RPT_SIZE;
 use core_foundation_sys::base::*;
-use u2fprotocol::U2FDevice;
+use u2ftypes::U2FDevice;
 
 use super::iokit::*;
 

--- a/src/u2fprotocol.rs
+++ b/src/u2fprotocol.rs
@@ -1,120 +1,13 @@
 extern crate std;
 
-use consts::*;
-use std::{ffi, mem, io, slice};
+use std::{cmp, io};
 use std::io::{Read, Write};
 use std::ffi::CString;
 
+use consts::*;
+use u2ftypes::*;
+
 use log;
-
-// Size of data chunk expected in U2F Init USB HID Packets
-const INIT_DATA_SIZE: usize = HID_RPT_SIZE - 7;
-// Size of data chunk expected in U2F Cont USB HID Packets
-const CONT_DATA_SIZE: usize = HID_RPT_SIZE - 5;
-
-// Init structure for U2F Communications. Tells the receiver what channel
-// communication is happening on, what command is running, and how much data to
-// expect to receive over all.
-//
-// Spec at https://fidoalliance.org/specs/fido-u2f-v1.
-// 0-nfc-bt-amendment-20150514/fido-u2f-hid-protocol.html#message--and-packet-structure
-#[repr(C)]
-struct U2FHIDInit {
-    // U2F Channel ID
-    cid: [u8; 4],
-    // U2F Command
-    cmd: u8,
-    // High byte of 16-bit data size
-    bcnth: u8,
-    // Low byte of 16-bit data size
-    bcntl: u8,
-    // Packet data
-    pub data: [u8; INIT_DATA_SIZE],
-}
-
-// Continuation structure for U2F Communications. After an Init structure is
-// sent, continuation structures are used to transmit all extra data that
-// wouldn't fit in the initial packet. The sequence number increases with every
-// packet, until all data is received.
-//
-// https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-hid-protocol.
-// html#message--and-packet-structure
-#[repr(C)]
-struct U2FHIDCont {
-    // U2F Channel ID
-    cid: [u8; 4],
-    // Continuation Sequence Number
-    seq: u8,
-    // Packet Data
-    pub data: [u8; CONT_DATA_SIZE],
-}
-
-// Reply sent after initialization command. Contains information about U2F USB
-// Key versioning, as well as the communication channel to be used for all
-// further requests.
-//
-// https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-hid-protocol.
-// html#u2fhid_init
-#[repr(C)]
-#[derive(Debug)]
-struct U2FHIDInitResp {
-    nonce: [u8; INIT_NONCE_SIZE],
-    cid: [u8; 4],
-    version_interface: u8,
-    version_major: u8,
-    version_minor: u8,
-    version_build: u8,
-    cap_flags: u8,
-}
-
-// Trait for representing U2F HID Devices. Requires getters/setters for the
-// channel ID, created during device initialization.
-pub trait U2FDevice {
-    fn get_cid(&self) -> [u8; 4];
-    fn set_cid(&mut self, cid: &[u8; 4]);
-}
-
-////////////////////////////////////////////////////////////////////////
-// Utility Functions
-////////////////////////////////////////////////////////////////////////
-
-fn to_u8_array<T>(non_ptr: &T) -> &[u8] {
-    unsafe { slice::from_raw_parts(non_ptr as *const T as *const u8, mem::size_of::<T>()) }
-}
-
-fn from_u8_array<T>(arr: &[u8]) -> &T {
-    if arr.len() > std::mem::size_of::<T>() {
-        panic!(
-            "from_u8_array attempting to overrun buffer, {} > {}",
-            arr.len(),
-            std::mem::size_of::<T>()
-        );
-    }
-    unsafe { &*(arr.as_ptr() as *const T) }
-}
-
-fn set_data(data: &mut [u8], itr: &mut std::slice::Iter<u8>, max: usize) {
-    let take_amount;
-    let count = itr.size_hint().0;
-    if max < count {
-        take_amount = max;
-    } else {
-        take_amount = count;
-    }
-    // TODO There is a better way to do this :|
-    for i in 0..take_amount {
-        if let Some(v) = itr.next() {
-            data[i] = *v;
-        } else {
-            warn!(
-                "set_data overrun; expected {} bytes but stopped at {}",
-                take_amount,
-                i
-            );
-            return;
-        }
-    }
-}
 
 ////////////////////////////////////////////////////////////////////////
 // Device Commands
@@ -125,13 +18,12 @@ where
     T: U2FDevice + Read + Write,
 {
     let raw = sendrecv(dev, U2FHID_INIT, &nonce)?;
-
-    let r: &U2FHIDInitResp = from_u8_array(&raw);
-    if r.nonce != nonce {
+    let r = U2FHIDInitResp::from_bytes(&raw)?;
+    if r.nonce() != nonce {
         return Err(io::Error::new(io::ErrorKind::Other, "Nonces do not match!"));
     }
 
-    dev.set_cid(&r.cid);
+    dev.set_cid(r.cid());
     Ok(())
 }
 
@@ -170,12 +62,12 @@ pub fn u2f_version<T>(dev: &mut T) -> io::Result<std::ffi::CString>
 where
     T: U2FDevice + Read + Write,
 {
-    let mut version_resp = try!(send_apdu(dev, U2F_VERSION, 0x00, &vec![]));
+    let mut version_resp = send_apdu(dev, U2F_VERSION, 0x00, &vec![])?;
     let sw_low = version_resp.pop().unwrap_or_default();
     let sw_high = version_resp.pop().unwrap_or_default();
 
     match status_word_to_error(sw_high, sw_low) {
-        None => Ok(try!(CString::new(version_resp))),
+        None => Ok(CString::new(version_resp)?),
         Some(e) => Err(e),
     }
 }
@@ -184,9 +76,9 @@ pub fn u2f_version_is_v2<T>(dev: &mut T) -> io::Result<()>
 where
     T: U2FDevice + Read + Write,
 {
-    let version_string = try!(u2f_version(dev));
+    let version_string = u2f_version(dev)?;
 
-    if version_string != try!(ffi::CString::new("U2F_V2")) {
+    if version_string != CString::new("U2F_V2")? {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "Unexpected U2F Version",
@@ -216,12 +108,12 @@ where
     register_data.extend(challenge);
     register_data.extend(application);
 
-    let register_resp = try!(send_apdu(
+    let register_resp = send_apdu(
         dev,
         U2F_REGISTER,
         flags | U2F_REQUEST_USER_PRESENCE,
         &register_data,
-    ));
+    )?;
 
     if register_resp.len() != 2 {
         // Real data, we're done
@@ -322,34 +214,26 @@ fn sendrecv<T>(dev: &mut T, cmd: u8, send: &[u8]) -> io::Result<Vec<u8>>
 where
     T: U2FDevice + Read + Write,
 {
-    let mut sequence: u8 = 0; // Start at 0
-    let mut data_itr = send.into_iter();
-    let mut init_sent = false;
+    let mut sequence = 0u8;
+    let mut data = send;
+
     // Write Data.
-    while data_itr.size_hint().0 != 0 {
-        // Add 1 to HID_RPT_SIZE since we need to prefix this with a record
-        // index.
-        let mut frame: [u8; HID_RPT_SIZE + 1] = [0; HID_RPT_SIZE + 1];
-        if !init_sent {
-            let mut uf = U2FHIDInit {
-                cid: dev.get_cid(),
-                cmd: cmd,
-                bcnth: (send.len() >> 8) as u8,
-                bcntl: send.len() as u8,
-                data: [0; INIT_DATA_SIZE],
-            };
-            set_data(&mut uf.data, &mut data_itr, INIT_DATA_SIZE);
-            frame[1..].clone_from_slice(to_u8_array(&uf));
-            init_sent = true;
+    while data.len() > 0 {
+        // HID_RPT_SIZE+1 since we need to prefix this with a record index.
+        let mut frame = [0; HID_RPT_SIZE + 1];
+
+        if data.len() == send.len() {
+            let max = cmp::min(data.len(), INIT_DATA_SIZE);
+            let uf = U2FHIDInit::new(dev, cmd, send.len(), &data[..max]);
+            uf.to_bytes(&mut frame[1..]);
+            data = &data[max..];
         } else {
-            let mut uf = U2FHIDCont {
-                cid: dev.get_cid(),
-                seq: sequence,
-                data: [0; CONT_DATA_SIZE],
-            };
-            set_data(&mut uf.data, &mut data_itr, CONT_DATA_SIZE);
+            // First cont package has seq=1.
+            let max = cmp::min(data.len(), CONT_DATA_SIZE);
+            let uf = U2FHIDCont::new(dev, sequence, &data[..max]);
+            uf.to_bytes(&mut frame[1..]);
+            data = &data[max..];
             sequence += 1;
-            frame[1..].clone_from_slice(to_u8_array(&uf));
         }
 
         if log_enabled!(log::LogLevel::Trace) {
@@ -357,77 +241,51 @@ where
             trace!("USB send: {}", parts.join(""));
         }
 
-        if let Err(er) = dev.write(&frame) {
-            return Err(er);
-        };
+        dev.write(&frame)?;
     }
 
     // Now we read. This happens in 2 chunks: The initial packet, which has the
     // size we expect overall, then continuation packets, which will fill in
     // data until we have everything.
-    let mut frame: [u8; HID_RPT_SIZE] = [0u8; HID_RPT_SIZE];
-    let datalen: usize;
-    let mut data: Vec<u8>;
-
+    let mut frame = [0u8; HID_RPT_SIZE];
     // TODO Check the status of the read, figure out how we'll deal with timeouts.
     dev.read(&mut frame)?;
-    let mut recvlen = INIT_DATA_SIZE;
 
     // We'll get an init packet back from USB, open it to see how much we'll be
-    // reading overall. (should unpack to an init struct). Scope this to deal
-    // with the lifetime of the frame borrow in from_u8_array.
-    {
-        let info_frame: &U2FHIDInit = from_u8_array(&frame);
+    // reading overall. (should unpack to an init struct).
+    let info_frame = U2FHIDInit::from_bytes(&frame)?;
 
-        // Read until we've exhausted the total read amount or error out
-        datalen = (info_frame.bcnth as usize) << 8 | (info_frame.bcntl as usize);
-        data = Vec::with_capacity(datalen);
+    // Read until we've exhausted the total read amount or error out
+    let datalen = info_frame.bcnt();
+    let mut data = Vec::with_capacity(datalen);
+    let clone_len = cmp::min(datalen, INIT_DATA_SIZE);
+    data.extend_from_slice(&info_frame.data()[..clone_len]);
 
-        let clone_len: usize;
-        if datalen < recvlen {
-            clone_len = datalen;
-        } else {
-            clone_len = recvlen;
-        }
-        data.extend(info_frame.data[0..clone_len].iter().cloned());
-    }
-    sequence = 0;
+    let mut sequence = 0;
+    let mut recvlen = INIT_DATA_SIZE;
     while recvlen < datalen {
-        // Reset frame value
-        frame = [0u8; HID_RPT_SIZE];
+        let mut frame = [0u8; HID_RPT_SIZE];
         dev.read(&mut frame)?;
-        let cont_frame: &U2FHIDCont;
-        cont_frame = from_u8_array(&frame);
-        if cont_frame.cid != dev.get_cid() {
+        let cont_frame = U2FHIDCont::from_bytes(&frame)?;
+        if cont_frame.cid() != dev.get_cid() {
             return Err(io::Error::new(io::ErrorKind::Other, "Wrong CID!"));
         }
-        if cont_frame.seq != sequence {
+        if cont_frame.sequence() != sequence {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
                 "Sequence numbers out of order!",
             ));
         }
-        sequence = cont_frame.seq + 1;
+        sequence += 1;
+        let mut payload = cont_frame.data();
+        // Truncate the last cont packet's data, if necessary.
         if (recvlen + CONT_DATA_SIZE) > datalen {
-            data.extend(cont_frame.data[0..(datalen - recvlen)].iter().cloned());
-        } else {
-            data.extend(cont_frame.data.iter().cloned());
+            payload = &payload[0..(datalen - recvlen)];
         }
+        data.extend_from_slice(payload);
         recvlen += CONT_DATA_SIZE;
     }
     Ok(data)
-}
-
-// https://en.wikipedia.org/wiki/Smart_card_application_protocol_data_unit
-// https://fidoalliance.org/specs/fido-u2f-v1.
-// 0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#u2f-message-framing
-#[repr(C)]
-struct U2FAPDUHeader {
-    cla: u8,
-    ins: u8,
-    p1: u8,
-    p2: u8,
-    lc: [u8; 3],
 }
 
 fn send_apdu<T>(dev: &mut T, cmd: u8, p1: u8, send: &Vec<u8>) -> io::Result<Vec<u8>>
@@ -435,22 +293,11 @@ where
     T: U2FDevice + Read + Write,
 {
     // TODO: Check send length to make sure it's < 2^16
-    let header = U2FAPDUHeader {
-        cla: 0,
-        ins: cmd,
-        p1: p1,
-        p2: 0, // p2 is always 0, at least, for our requirements.
-        lc: [
-            0, // lc[0] should always be 0
-            (send.len() >> 8) as u8,
-            (send.len() & 0xff) as u8,
-        ],
-    };
+    let header = U2FAPDUHeader::new(cmd, p1, send.len());
     // Size of header, plus data, plus 2 0 bytes at the end for maximum return
     // size.
-    let mut data_vec: Vec<u8> = vec![0; std::mem::size_of::<U2FAPDUHeader>() + send.len() + 2];
-    let header_raw: &[u8] = to_u8_array(&header);
-    data_vec[0..U2FAPDUHEADER_SIZE].clone_from_slice(&header_raw);
+    let mut data_vec: Vec<u8> = vec![0; U2FAPDUHEADER_SIZE + send.len() + 2];
+    header.to_bytes(&mut data_vec[..U2FAPDUHEADER_SIZE]);
     data_vec[U2FAPDUHEADER_SIZE..(send.len() + U2FAPDUHEADER_SIZE)].clone_from_slice(&send);
     sendrecv(dev, U2FHID_MSG, &data_vec)
 }
@@ -462,7 +309,7 @@ mod tests {
     use consts::{U2FHID_PING, U2FHID_MSG};
     mod platform {
         use consts::{CID_BROADCAST, HID_RPT_SIZE};
-        use u2fprotocol::U2FDevice;
+        use u2ftypes::U2FDevice;
         use std::io;
         use std::io::{Read, Write};
 

--- a/src/u2ftypes.rs
+++ b/src/u2ftypes.rs
@@ -1,0 +1,245 @@
+use std::io;
+
+use consts::*;
+use util::io_err;
+
+// Trait for representing U2F HID Devices. Requires getters/setters for the
+// channel ID, created during device initialization.
+pub trait U2FDevice {
+    fn get_cid(&self) -> [u8; 4];
+    fn set_cid(&mut self, cid: &[u8; 4]);
+}
+
+// Init structure for U2F Communications. Tells the receiver what channel
+// communication is happening on, what command is running, and how much data to
+// expect to receive over all.
+//
+// Spec at https://fidoalliance.org/specs/fido-u2f-v1.
+// 0-nfc-bt-amendment-20150514/fido-u2f-hid-protocol.html#message--and-packet-structure
+pub struct U2FHIDInit {
+    // U2F Channel ID
+    cid: [u8; 4],
+    // U2F Command
+    cmd: u8,
+    // High byte of 16-bit data size
+    bcnth: u8,
+    // Low byte of 16-bit data size
+    bcntl: u8,
+    // Packet data
+    data: [u8; INIT_DATA_SIZE],
+}
+
+impl U2FHIDInit {
+    pub fn new<T>(dev: &T, cmd: u8, bcnt: usize, init_data: &[u8]) -> Self
+    where
+        T: U2FDevice,
+    {
+        let len = init_data.len();
+        let mut data = [0u8; INIT_DATA_SIZE];
+        data[..len].copy_from_slice(&init_data[..len]);
+
+        Self {
+            cid: dev.get_cid(),
+            cmd,
+            bcnth: (bcnt >> 8) as u8,
+            bcntl: bcnt as u8,
+            data,
+        }
+    }
+
+    pub fn from_bytes(buf: &[u8]) -> io::Result<Self> {
+        if buf.len() != HID_RPT_SIZE {
+            return Err(io_err("invalid init packet"));
+        }
+
+        let mut cid = [0u8; 4];
+        cid.copy_from_slice(&buf[..4]);
+
+        let mut data = [0u8; INIT_DATA_SIZE];
+        data.copy_from_slice(&buf[7..]);
+
+        Ok(Self {
+            cid,
+            cmd: buf[4],
+            bcnth: buf[5],
+            bcntl: buf[6],
+            data,
+        })
+    }
+
+    pub fn to_bytes(&self, buf: &mut [u8]) {
+        assert!(buf.len() == HID_RPT_SIZE);
+
+        buf[..4].copy_from_slice(&self.cid);
+        buf[4] = self.cmd;
+        buf[5] = self.bcnth;
+        buf[6] = self.bcntl;
+        buf[7..].copy_from_slice(&self.data);
+    }
+
+    pub fn bcnt(&self) -> usize {
+        (self.bcnth as usize) << 8 | (self.bcntl as usize)
+    }
+
+    pub fn data<'a>(&'a self) -> &'a [u8] {
+        &self.data
+    }
+}
+
+// Continuation structure for U2F Communications. After an Init structure is
+// sent, continuation structures are used to transmit all extra data that
+// wouldn't fit in the initial packet. The sequence number increases with every
+// packet, until all data is received.
+//
+// https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-hid-protocol.
+// html#message--and-packet-structure
+pub struct U2FHIDCont {
+    // U2F Channel ID
+    cid: [u8; 4],
+    // Continuation Sequence Number
+    seq: u8,
+    // Packet Data
+    data: [u8; CONT_DATA_SIZE],
+}
+
+impl U2FHIDCont {
+    pub fn new<T>(dev: &T, seq: u8, cont_data: &[u8]) -> Self
+    where
+        T: U2FDevice,
+    {
+        let len = cont_data.len();
+        let mut data = [0u8; CONT_DATA_SIZE];
+        data[..len].copy_from_slice(&cont_data[..len]);
+
+        Self {
+            cid: dev.get_cid(),
+            seq,
+            data,
+        }
+    }
+
+    pub fn from_bytes(buf: &[u8]) -> io::Result<Self> {
+        if buf.len() != HID_RPT_SIZE {
+            return Err(io_err("invalid cont packet"));
+        }
+
+        let mut cid = [0u8; 4];
+        cid.copy_from_slice(&buf[..4]);
+
+        let mut data = [0u8; CONT_DATA_SIZE];
+        data.copy_from_slice(&buf[5..]);
+
+        Ok(Self {
+            cid,
+            seq: buf[4],
+            data,
+        })
+    }
+
+    pub fn to_bytes(&self, buf: &mut [u8]) {
+        assert!(buf.len() == HID_RPT_SIZE);
+
+        buf[..4].copy_from_slice(&self.cid);
+        buf[4] = self.seq;
+        buf[5..].copy_from_slice(&self.data);
+    }
+
+    pub fn cid<'a>(&'a self) -> &'a [u8] {
+        &self.cid
+    }
+
+    pub fn sequence(&self) -> u8 {
+        self.seq
+    }
+
+    pub fn data<'a>(&'a self) -> &'a [u8] {
+        &self.data
+    }
+}
+
+
+// Reply sent after initialization command. Contains information about U2F USB
+// Key versioning, as well as the communication channel to be used for all
+// further requests.
+//
+// https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-hid-protocol.
+// html#u2fhid_init
+#[derive(Debug)]
+pub struct U2FHIDInitResp {
+    nonce: [u8; INIT_NONCE_SIZE],
+    cid: [u8; 4],
+    version_interface: u8,
+    version_major: u8,
+    version_minor: u8,
+    version_build: u8,
+    cap_flags: u8,
+}
+
+impl U2FHIDInitResp {
+    pub fn from_bytes(buf: &[u8]) -> io::Result<Self> {
+        if buf.len() != INIT_NONCE_SIZE + 9 {
+            return Err(io_err("invalid init response"));
+        }
+
+        let mut nonce = [0u8; INIT_NONCE_SIZE];
+        nonce.copy_from_slice(&buf[..INIT_NONCE_SIZE]);
+
+        let mut cid = [0u8; 4];
+        cid.copy_from_slice(&buf[INIT_NONCE_SIZE..INIT_NONCE_SIZE + 4]);
+
+        Ok(Self {
+            nonce,
+            cid,
+            version_interface: buf[INIT_NONCE_SIZE + 4],
+            version_major: buf[INIT_NONCE_SIZE + 5],
+            version_minor: buf[INIT_NONCE_SIZE + 6],
+            version_build: buf[INIT_NONCE_SIZE + 7],
+            cap_flags: buf[INIT_NONCE_SIZE + 8],
+        })
+    }
+
+    pub fn nonce<'a>(&'a self) -> &'a [u8] {
+        &self.nonce
+    }
+
+    pub fn cid<'a>(&'a self) -> &'a [u8; 4] {
+        &self.cid
+    }
+}
+
+// https://en.wikipedia.org/wiki/Smart_card_application_protocol_data_unit
+// https://fidoalliance.org/specs/fido-u2f-v1.
+// 0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#u2f-message-framing
+pub struct U2FAPDUHeader {
+    cla: u8,
+    ins: u8,
+    p1: u8,
+    p2: u8,
+    lc: [u8; 3],
+}
+
+impl U2FAPDUHeader {
+    pub fn new(ins: u8, p1: u8, lc: usize) -> Self {
+        Self {
+            cla: 0,
+            ins,
+            p1,
+            p2: 0, // p2 is always 0, at least, for our requirements.
+            lc: [
+                0, // lc[0] should always be 0
+                (lc >> 8) as u8,
+                (lc & 0xff) as u8,
+            ],
+        }
+    }
+
+    pub fn to_bytes(&self, buf: &mut [u8]) {
+        assert!(buf.len() == U2FAPDUHEADER_SIZE);
+
+        buf[0] = self.cla;
+        buf[1] = self.ins;
+        buf[2] = self.p1;
+        buf[3] = self.p2;
+        buf[4..].copy_from_slice(&self.lc);
+    }
+}

--- a/src/windows/device.rs
+++ b/src/windows/device.rs
@@ -6,7 +6,7 @@ use std::os::windows::io::AsRawHandle;
 use consts::{CID_BROADCAST, HID_RPT_SIZE, FIDO_USAGE_PAGE, FIDO_USAGE_U2FHID};
 use super::winapi::DeviceCapabilities;
 
-use u2fprotocol::U2FDevice;
+use u2ftypes::U2FDevice;
 
 #[derive(Debug)]
 pub struct Device {


### PR DESCRIPTION
Can you give this a try on your machine and see if it fixes the crashes you see? Even if it doesn't, I think this is still a valuable thing to do.