### PR TITLE
Simplify U2F packet communication, remove unused fields

### DIFF
--- a/src/linux/device.rs
+++ b/src/linux/device.rs
@@ -69,11 +69,11 @@ impl Write for Device {
 }
 
 impl U2FDevice for Device {
-    fn get_cid(&self) -> [u8; 4] {
-        self.cid.clone()
+    fn get_cid<'a>(&'a self) -> &'a [u8; 4] {
+        &self.cid
     }
 
-    fn set_cid(&mut self, cid: &[u8; 4]) {
-        self.cid.clone_from(cid);
+    fn set_cid(&mut self, cid: [u8; 4]) {
+        self.cid = cid;
     }
 }

--- a/src/macos/device.rs
+++ b/src/macos/device.rs
@@ -88,12 +88,12 @@ impl Write for Device {
 }
 
 impl U2FDevice for Device {
-    fn get_cid(&self) -> [u8; 4] {
-        return self.cid.clone();
+    fn get_cid<'a>(&'a self) -> &'a [u8; 4] {
+        &self.cid
     }
 
-    fn set_cid(&mut self, cid: &[u8; 4]) {
-        self.cid.clone_from(cid);
+    fn set_cid(&mut self, cid: [u8; 4]) {
+        self.cid = cid;
     }
 }
 
@@ -120,5 +120,5 @@ unsafe fn set_report(
     }
     trace!("set_report sending success = {0:X}", result);
 
-    Ok(length as usize)
+    Ok(bytes.len())
 }

--- a/src/u2fprotocol.rs
+++ b/src/u2fprotocol.rs
@@ -1,13 +1,12 @@
 extern crate std;
 
-use std::{cmp, io};
+use std::io;
 use std::io::{Read, Write};
 use std::ffi::CString;
 
 use consts::*;
 use u2ftypes::*;
-
-use log;
+use util::io_err;
 
 ////////////////////////////////////////////////////////////////////////
 // Device Commands
@@ -18,12 +17,7 @@ where
     T: U2FDevice + Read + Write,
 {
     let raw = sendrecv(dev, U2FHID_INIT, &nonce)?;
-    let r = U2FHIDInitResp::from_bytes(&raw)?;
-    if r.nonce() != nonce {
-        return Err(io::Error::new(io::ErrorKind::Other, "Nonces do not match!"));
-    }
-
-    dev.set_cid(r.cid());
+    dev.set_cid(U2FHIDInitResp::read(&raw, &nonce)?);
     Ok(())
 }
 
@@ -32,7 +26,7 @@ where
     T: U2FDevice + Read + Write,
 {
     if sendrecv(dev, U2FHID_PING, &random)? != random {
-        return Err(io::Error::new(io::ErrorKind::Other, "Ping was corrupted!"));
+        return Err(io_err("Ping was corrupted!"));
     }
 
     Ok(())
@@ -200,10 +194,7 @@ where
 
     let flags = U2F_CHECK_IS_REGISTERED;
     let sign_resp = send_apdu(dev, U2F_AUTHENTICATE, flags, &sign_data)?;
-
-    // Need to use `&sign_resp[0..2]` here due to a compiler bug.
-    // https://github.com/rust-lang/rust/issues/42031
-    Ok(&sign_resp[0..2] == SW_CONDITIONS_NOT_SATISFIED)
+    Ok(sign_resp == SW_CONDITIONS_NOT_SATISFIED)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -214,77 +205,28 @@ fn sendrecv<T>(dev: &mut T, cmd: u8, send: &[u8]) -> io::Result<Vec<u8>>
 where
     T: U2FDevice + Read + Write,
 {
+    // Send initialization packet.
+    let mut count = U2FHIDInit::write(dev, cmd, send)?;
+
+    // Send continuation packets.
     let mut sequence = 0u8;
-    let mut data = send;
-
-    // Write Data.
-    while data.len() > 0 {
-        // HID_RPT_SIZE+1 since we need to prefix this with a record index.
-        let mut frame = [0; HID_RPT_SIZE + 1];
-
-        if data.len() == send.len() {
-            let max = cmp::min(data.len(), INIT_DATA_SIZE);
-            let uf = U2FHIDInit::new(dev, cmd, send.len(), &data[..max]);
-            uf.to_bytes(&mut frame[1..]);
-            data = &data[max..];
-        } else {
-            // First cont package has seq=1.
-            let max = cmp::min(data.len(), CONT_DATA_SIZE);
-            let uf = U2FHIDCont::new(dev, sequence, &data[..max]);
-            uf.to_bytes(&mut frame[1..]);
-            data = &data[max..];
-            sequence += 1;
-        }
-
-        if log_enabled!(log::LogLevel::Trace) {
-            let parts: Vec<String> = frame.iter().map(|byte| format!("{:02x}", byte)).collect();
-            trace!("USB send: {}", parts.join(""));
-        }
-
-        dev.write(&frame)?;
+    while count < send.len() {
+        count += U2FHIDCont::write(dev, sequence, &send[count..])?;
+        sequence += 1;
     }
 
     // Now we read. This happens in 2 chunks: The initial packet, which has the
     // size we expect overall, then continuation packets, which will fill in
     // data until we have everything.
-    let mut frame = [0u8; HID_RPT_SIZE];
-    // TODO Check the status of the read, figure out how we'll deal with timeouts.
-    dev.read(&mut frame)?;
+    let mut data = U2FHIDInit::read(dev)?;
 
-    // We'll get an init packet back from USB, open it to see how much we'll be
-    // reading overall. (should unpack to an init struct).
-    let info_frame = U2FHIDInit::from_bytes(&frame)?;
-
-    // Read until we've exhausted the total read amount or error out
-    let datalen = info_frame.bcnt();
-    let mut data = Vec::with_capacity(datalen);
-    let clone_len = cmp::min(datalen, INIT_DATA_SIZE);
-    data.extend_from_slice(&info_frame.data()[..clone_len]);
-
-    let mut sequence = 0;
-    let mut recvlen = INIT_DATA_SIZE;
-    while recvlen < datalen {
-        let mut frame = [0u8; HID_RPT_SIZE];
-        dev.read(&mut frame)?;
-        let cont_frame = U2FHIDCont::from_bytes(&frame)?;
-        if cont_frame.cid() != dev.get_cid() {
-            return Err(io::Error::new(io::ErrorKind::Other, "Wrong CID!"));
-        }
-        if cont_frame.sequence() != sequence {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Sequence numbers out of order!",
-            ));
-        }
+    let mut sequence = 0u8;
+    while data.len() < data.capacity() {
+        let max = data.capacity() - data.len();
+        data.extend_from_slice(&U2FHIDCont::read(dev, sequence, max)?);
         sequence += 1;
-        let mut payload = cont_frame.data();
-        // Truncate the last cont packet's data, if necessary.
-        if (recvlen + CONT_DATA_SIZE) > datalen {
-            payload = &payload[0..(datalen - recvlen)];
-        }
-        data.extend_from_slice(payload);
-        recvlen += CONT_DATA_SIZE;
     }
+
     Ok(data)
 }
 
@@ -292,14 +234,7 @@ fn send_apdu<T>(dev: &mut T, cmd: u8, p1: u8, send: &Vec<u8>) -> io::Result<Vec<
 where
     T: U2FDevice + Read + Write,
 {
-    // TODO: Check send length to make sure it's < 2^16
-    let header = U2FAPDUHeader::new(cmd, p1, send.len());
-    // Size of header, plus data, plus 2 0 bytes at the end for maximum return
-    // size.
-    let mut data_vec: Vec<u8> = vec![0; U2FAPDUHEADER_SIZE + send.len() + 2];
-    header.to_bytes(&mut data_vec[..U2FAPDUHEADER_SIZE]);
-    data_vec[U2FAPDUHEADER_SIZE..(send.len() + U2FAPDUHEADER_SIZE)].clone_from_slice(&send);
-    sendrecv(dev, U2FHID_MSG, &data_vec)
+    sendrecv(dev, U2FHID_MSG, &U2FAPDUHeader::to_bytes(cmd, p1, send)?)
 }
 
 #[cfg(test)]
@@ -375,11 +310,11 @@ mod tests {
             }
         }
         impl U2FDevice for TestDevice {
-            fn get_cid(&self) -> [u8; 4] {
-                return self.cid.clone();
+            fn get_cid<'a>(&'a self) -> &'a [u8; 4] {
+                &self.cid
             }
-            fn set_cid(&mut self, cid: &[u8; 4]) {
-                self.cid = cid.clone();
+            fn set_cid(&mut self, cid: [u8; 4]) {
+                self.cid = cid;
             }
         }
     }
@@ -444,13 +379,13 @@ mod tests {
                 format!("Init device returned an error! {:?}", e.description())
             );
         }
-        assert_eq!(device.get_cid(), [0x00, 0x03, 0x00, 0x14]);
+        assert_eq!(device.get_cid(), &[0x00, 0x03, 0x00, 0x14]);
     }
 
     #[test]
     fn test_sendrecv_multiple() {
         let mut device = platform::TestDevice::new();
-        device.set_cid(&[1, 2, 3, 4]);
+        device.set_cid([1, 2, 3, 4]);
         device.add_write(&vec![0x01, 0x02, 0x03, 0x04, U2FHID_PING, 0x00, 0xe4], 1);
         // Need CID and sequence number for CONT packets
         device.add_write(&vec![0x01, 0x02, 0x03, 0x04, 0x00], 1);
@@ -602,7 +537,7 @@ mod tests {
     #[test]
     fn test_sendapdu() {
         let mut device = platform::TestDevice::new();
-        device.set_cid(&[1, 2, 3, 4]);
+        device.set_cid([1, 2, 3, 4]);
         device.add_write(
             &vec![
                 // sendrecv header
@@ -654,7 +589,7 @@ mod tests {
     #[test]
     fn test_ping_device() {
         let mut device = platform::TestDevice::new();
-        device.set_cid(&[1, 2, 3, 4]);
+        device.set_cid([1, 2, 3, 4]);
         device.add_write(
             &vec![
                 // apdu header

--- a/src/u2ftypes.rs
+++ b/src/u2ftypes.rs
@@ -1,13 +1,22 @@
-use std::io;
+use std::{cmp, io};
 
 use consts::*;
 use util::io_err;
 
+use log;
+
+fn trace_hex(data: &[u8]) {
+    if log_enabled!(log::LogLevel::Trace) {
+        let parts: Vec<String> = data.iter().map(|byte| format!("{:02x}", byte)).collect();
+        trace!("USB send: {}", parts.join(""));
+    }
+}
+
 // Trait for representing U2F HID Devices. Requires getters/setters for the
 // channel ID, created during device initialization.
 pub trait U2FDevice {
-    fn get_cid(&self) -> [u8; 4];
-    fn set_cid(&mut self, cid: &[u8; 4]);
+    fn get_cid<'a>(&'a self) -> &'a [u8; 4];
+    fn set_cid(&mut self, cid: [u8; 4]);
 }
 
 // Init structure for U2F Communications. Tells the receiver what channel
@@ -16,73 +25,56 @@ pub trait U2FDevice {
 //
 // Spec at https://fidoalliance.org/specs/fido-u2f-v1.
 // 0-nfc-bt-amendment-20150514/fido-u2f-hid-protocol.html#message--and-packet-structure
-pub struct U2FHIDInit {
-    // U2F Channel ID
-    cid: [u8; 4],
-    // U2F Command
-    cmd: u8,
-    // High byte of 16-bit data size
-    bcnth: u8,
-    // Low byte of 16-bit data size
-    bcntl: u8,
-    // Packet data
-    data: [u8; INIT_DATA_SIZE],
-}
+pub struct U2FHIDInit {}
 
 impl U2FHIDInit {
-    pub fn new<T>(dev: &T, cmd: u8, bcnt: usize, init_data: &[u8]) -> Self
+    pub fn read<T>(dev: &mut T) -> io::Result<Vec<u8>>
     where
-        T: U2FDevice,
+        T: U2FDevice + io::Read,
     {
-        let len = init_data.len();
-        let mut data = [0u8; INIT_DATA_SIZE];
-        data[..len].copy_from_slice(&init_data[..len]);
+        let mut frame = [0u8; HID_RPT_SIZE];
+        let count = dev.read(&mut frame)?;
 
-        Self {
-            cid: dev.get_cid(),
-            cmd,
-            bcnth: (bcnt >> 8) as u8,
-            bcntl: bcnt as u8,
-            data,
-        }
-    }
-
-    pub fn from_bytes(buf: &[u8]) -> io::Result<Self> {
-        if buf.len() != HID_RPT_SIZE {
+        if count != HID_RPT_SIZE {
             return Err(io_err("invalid init packet"));
         }
 
-        let mut cid = [0u8; 4];
-        cid.copy_from_slice(&buf[..4]);
+        if dev.get_cid() != &frame[..4] {
+            return Err(io_err("invalid channel id"));
+        }
 
-        let mut data = [0u8; INIT_DATA_SIZE];
-        data.copy_from_slice(&buf[7..]);
+        let cap = (frame[5] as usize) << 8 | (frame[6] as usize);
+        let mut data = Vec::with_capacity(cap);
 
-        Ok(Self {
-            cid,
-            cmd: buf[4],
-            bcnth: buf[5],
-            bcntl: buf[6],
-            data,
-        })
+        let len = cmp::min(cap, INIT_DATA_SIZE);
+        data.extend_from_slice(&frame[7..7 + len]);
+
+        Ok(data)
     }
 
-    pub fn to_bytes(&self, buf: &mut [u8]) {
-        assert!(buf.len() == HID_RPT_SIZE);
+    pub fn write<T>(dev: &mut T, cmd: u8, data: &[u8]) -> io::Result<usize>
+    where
+        T: U2FDevice + io::Write,
+    {
+        if data.len() > 0xffff {
+            return Err(io_err("payload length > 2^16"));
+        }
 
-        buf[..4].copy_from_slice(&self.cid);
-        buf[4] = self.cmd;
-        buf[5] = self.bcnth;
-        buf[6] = self.bcntl;
-        buf[7..].copy_from_slice(&self.data);
-    }
+        let mut frame = [0; HID_RPT_SIZE + 1];
+        frame[1..5].copy_from_slice(dev.get_cid());
+        frame[5] = cmd;
+        frame[6] = (data.len() >> 8) as u8;
+        frame[7] = data.len() as u8;
 
-    pub fn bcnt(&self) -> usize {
-        (self.bcnth as usize) << 8 | (self.bcntl as usize)
-    }
+        let count = cmp::min(data.len(), INIT_DATA_SIZE);
+        frame[8..8 + count].copy_from_slice(&data[..count]);
+        trace_hex(&frame);
 
-    pub fn data<'a>(&'a self) -> &'a [u8] {
-        &self.data
+        if dev.write(&frame)? != frame.len() {
+            return Err(io_err("device write failed"));
+        }
+
+        Ok(count)
     }
 }
 
@@ -93,67 +85,49 @@ impl U2FHIDInit {
 //
 // https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-hid-protocol.
 // html#message--and-packet-structure
-pub struct U2FHIDCont {
-    // U2F Channel ID
-    cid: [u8; 4],
-    // Continuation Sequence Number
-    seq: u8,
-    // Packet Data
-    data: [u8; CONT_DATA_SIZE],
-}
+pub struct U2FHIDCont {}
 
 impl U2FHIDCont {
-    pub fn new<T>(dev: &T, seq: u8, cont_data: &[u8]) -> Self
+    pub fn read<T>(dev: &mut T, seq: u8, max: usize) -> io::Result<Vec<u8>>
     where
-        T: U2FDevice,
+        T: U2FDevice + io::Read,
     {
-        let len = cont_data.len();
-        let mut data = [0u8; CONT_DATA_SIZE];
-        data[..len].copy_from_slice(&cont_data[..len]);
+        let mut frame = [0u8; HID_RPT_SIZE];
+        let count = dev.read(&mut frame)?;
 
-        Self {
-            cid: dev.get_cid(),
-            seq,
-            data,
-        }
-    }
-
-    pub fn from_bytes(buf: &[u8]) -> io::Result<Self> {
-        if buf.len() != HID_RPT_SIZE {
+        if count != HID_RPT_SIZE {
             return Err(io_err("invalid cont packet"));
         }
 
-        let mut cid = [0u8; 4];
-        cid.copy_from_slice(&buf[..4]);
+        if dev.get_cid() != &frame[..4] {
+            return Err(io_err("invalid channel id"));
+        }
 
-        let mut data = [0u8; CONT_DATA_SIZE];
-        data.copy_from_slice(&buf[5..]);
+        if seq != frame[4] {
+            return Err(io_err("invalid sequence number"));
+        }
 
-        Ok(Self {
-            cid,
-            seq: buf[4],
-            data,
-        })
+        let max = cmp::min(max, CONT_DATA_SIZE);
+        Ok(frame[5..5 + max].to_vec())
     }
 
-    pub fn to_bytes(&self, buf: &mut [u8]) {
-        assert!(buf.len() == HID_RPT_SIZE);
+    pub fn write<T>(dev: &mut T, seq: u8, data: &[u8]) -> io::Result<usize>
+    where
+        T: U2FDevice + io::Write,
+    {
+        let mut frame = [0; HID_RPT_SIZE + 1];
+        frame[1..5].copy_from_slice(dev.get_cid());
+        frame[5] = seq;
 
-        buf[..4].copy_from_slice(&self.cid);
-        buf[4] = self.seq;
-        buf[5..].copy_from_slice(&self.data);
-    }
+        let count = cmp::min(data.len(), CONT_DATA_SIZE);
+        frame[6..6 + count].copy_from_slice(&data[..count]);
+        trace_hex(&frame);
 
-    pub fn cid<'a>(&'a self) -> &'a [u8] {
-        &self.cid
-    }
+        if dev.write(&frame)? != frame.len() {
+            return Err(io_err("device write failed"));
+        }
 
-    pub fn sequence(&self) -> u8 {
-        self.seq
-    }
-
-    pub fn data<'a>(&'a self) -> &'a [u8] {
-        &self.data
+        Ok(count)
     }
 }
 
@@ -164,82 +138,45 @@ impl U2FHIDCont {
 //
 // https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-hid-protocol.
 // html#u2fhid_init
-#[derive(Debug)]
-pub struct U2FHIDInitResp {
-    nonce: [u8; INIT_NONCE_SIZE],
-    cid: [u8; 4],
-    version_interface: u8,
-    version_major: u8,
-    version_minor: u8,
-    version_build: u8,
-    cap_flags: u8,
-}
+pub struct U2FHIDInitResp {}
 
 impl U2FHIDInitResp {
-    pub fn from_bytes(buf: &[u8]) -> io::Result<Self> {
-        if buf.len() != INIT_NONCE_SIZE + 9 {
+    pub fn read(data: &[u8], nonce: &[u8; INIT_NONCE_SIZE]) -> io::Result<[u8; 4]> {
+        if data.len() != INIT_NONCE_SIZE + 9 {
             return Err(io_err("invalid init response"));
         }
 
-        let mut nonce = [0u8; INIT_NONCE_SIZE];
-        nonce.copy_from_slice(&buf[..INIT_NONCE_SIZE]);
+        if nonce != &data[..INIT_NONCE_SIZE] {
+            return Err(io_err("invalid nonce"));
+        }
 
         let mut cid = [0u8; 4];
-        cid.copy_from_slice(&buf[INIT_NONCE_SIZE..INIT_NONCE_SIZE + 4]);
-
-        Ok(Self {
-            nonce,
-            cid,
-            version_interface: buf[INIT_NONCE_SIZE + 4],
-            version_major: buf[INIT_NONCE_SIZE + 5],
-            version_minor: buf[INIT_NONCE_SIZE + 6],
-            version_build: buf[INIT_NONCE_SIZE + 7],
-            cap_flags: buf[INIT_NONCE_SIZE + 8],
-        })
-    }
-
-    pub fn nonce<'a>(&'a self) -> &'a [u8] {
-        &self.nonce
-    }
-
-    pub fn cid<'a>(&'a self) -> &'a [u8; 4] {
-        &self.cid
+        cid.copy_from_slice(&data[INIT_NONCE_SIZE..INIT_NONCE_SIZE + 4]);
+        Ok(cid)
     }
 }
 
 // https://en.wikipedia.org/wiki/Smart_card_application_protocol_data_unit
 // https://fidoalliance.org/specs/fido-u2f-v1.
 // 0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#u2f-message-framing
-pub struct U2FAPDUHeader {
-    cla: u8,
-    ins: u8,
-    p1: u8,
-    p2: u8,
-    lc: [u8; 3],
-}
+pub struct U2FAPDUHeader {}
 
 impl U2FAPDUHeader {
-    pub fn new(ins: u8, p1: u8, lc: usize) -> Self {
-        Self {
-            cla: 0,
-            ins,
-            p1,
-            p2: 0, // p2 is always 0, at least, for our requirements.
-            lc: [
-                0, // lc[0] should always be 0
-                (lc >> 8) as u8,
-                (lc & 0xff) as u8,
-            ],
+    pub fn to_bytes(ins: u8, p1: u8, data: &[u8]) -> io::Result<Vec<u8>> {
+        if data.len() > 0xffff {
+            return Err(io_err("payload length > 2^16"));
         }
-    }
 
-    pub fn to_bytes(&self, buf: &mut [u8]) {
-        assert!(buf.len() == U2FAPDUHEADER_SIZE);
+        // Size of header + data + 2 zero bytes for maximum return size.
+        let mut bytes = vec![0u8; U2FAPDUHEADER_SIZE + data.len() + 2];
+        bytes[1] = ins;
+        bytes[2] = p1;
+        // p2 is always 0, at least, for our requirements.
+        // lc[0] should always be 0.
+        bytes[5] = (data.len() >> 8) as u8;
+        bytes[6] = data.len() as u8;
+        bytes[7..7 + data.len()].copy_from_slice(data);
 
-        buf[0] = self.cla;
-        buf[1] = self.ins;
-        buf[2] = self.p1;
-        buf[3] = self.p2;
-        buf[4..].copy_from_slice(&self.lc);
+        Ok(bytes)
     }
 }

--- a/src/windows/device.rs
+++ b/src/windows/device.rs
@@ -60,11 +60,11 @@ impl Write for Device {
 }
 
 impl U2FDevice for Device {
-    fn get_cid(&self) -> [u8; 4] {
-        self.cid.clone()
+    fn get_cid<'a>(&'a self) -> &'a [u8; 4] {
+        &self.cid
     }
 
-    fn set_cid(&mut self, cid: &[u8; 4]) {
-        self.cid.clone_from(cid);
+    fn set_cid(&mut self, cid: [u8; 4]) {
+        self.cid = cid;
     }
 }


### PR DESCRIPTION
Simplify U2F packet reading and writing some more. Remove fields we never used. Fuzzing should be easier to implement with the new APIs.

r? @jcjones 