### PR TITLE
Fix u2f-hid-rs to compile Fennec from OSX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "u2fhid"
 version = "0.1.0"
 authors = ["Kyle Machulis <kyle@nonpolynomial.com>", "J.C. Jones <jc@mozilla.com>", "Tim Taubert <ttaubert@mozilla.com>"]
-build = "build.rs"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libudev = "^0.2"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-fn main() {
-    #[cfg(any(target_os = "macos"))]
-    println!("cargo:rustc-link-lib=framework=IOKit");
-}

--- a/src/macos/iokit.rs
+++ b/src/macos/iokit.rs
@@ -50,6 +50,7 @@ pub struct IOHIDDeviceRef(*const c_void);
 unsafe impl Send for IOHIDDeviceRef {}
 unsafe impl Sync for IOHIDDeviceRef {}
 
+#[link(name = "IOKit", kind = "framework")]
 extern "C" {
     // IOHIDManager
     pub fn IOHIDManagerCreate(


### PR DESCRIPTION
For OSX, u2f-hid-rs uses "build.rs" to set appropriate linker flags.
Unfortunately, when cross-compiling to Android on OSX, build.rs is setting
those flags even though target_os is (theoretically) now Android. There's
almost certainly a perfectly reasonable explanation for why this is so, but for
now, this patch is a hack to un-break Fennec builds on OSX by playing off of
target_env in addition to target_os.