### PR TITLE
Allow build failures from Rust nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ rust:
   - beta
   - nightly
 
+matrix:
+  allow_failures:
+    - rust: nightly
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
This is the recommended configuration of Rust project in Travis, see https://docs.travis-ci.com/user/languages/rust/#Choosing-a-Rust-version