### PR TITLE
Update core-foundation and use it to clean up some code.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ libudev = "^0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation-sys = "0.6.0"
+core-foundation = "0.6.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.2.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Kyle Machulis <kyle@nonpolynomial.com>", "J.C. Jones <jc@mozilla.com
 libudev = "^0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation-sys = "0.5.1"
+core-foundation-sys = "0.6.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.2.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@ pub mod platform;
 extern crate core_foundation_sys;
 
 #[cfg(any(target_os = "macos"))]
+extern crate core_foundation;
+
+#[cfg(any(target_os = "macos"))]
 #[path = "macos/mod.rs"]
 pub mod platform;
 

--- a/src/macos/iokit.rs
+++ b/src/macos/iokit.rs
@@ -13,7 +13,7 @@ use core_foundation_sys::dictionary::*;
 use core_foundation_sys::number::*;
 use core_foundation_sys::runloop::*;
 use core_foundation_sys::string::*;
-use libc::c_void;
+use std::os::raw::c_void;
 use std::ops::Deref;
 
 type IOOptionBits = u32;
@@ -172,8 +172,8 @@ impl IOHIDDeviceMatcher {
         let dict = unsafe {
             CFDictionaryCreate(
                 kCFAllocatorDefault,
-                keys.as_ptr() as *const *const libc::c_void,
-                values.as_ptr() as *const *const libc::c_void,
+                keys.as_ptr() as *const *const c_void,
+                values.as_ptr() as *const *const c_void,
                 keys.len() as CFIndex,
                 &kCFTypeDictionaryKeyCallBacks,
                 &kCFTypeDictionaryValueCallBacks,
@@ -185,7 +185,7 @@ impl IOHIDDeviceMatcher {
 
     fn cf_number(number: i32) -> CFNumberRef {
         let nbox = Box::new(number);
-        let nptr = Box::into_raw(nbox) as *mut libc::c_void;
+        let nptr = Box::into_raw(nbox) as *mut c_void;
 
         unsafe {
             // Drop when out of scope.
@@ -213,14 +213,14 @@ impl IOHIDDeviceMatcher {
 
 impl Drop for IOHIDDeviceMatcher {
     fn drop(&mut self) {
-        unsafe { CFRelease(self.dict as *mut libc::c_void) };
+        unsafe { CFRelease(self.dict as *mut c_void) };
 
         for key in &self.keys {
-            unsafe { CFRelease(*key as *mut libc::c_void) };
+            unsafe { CFRelease(*key as *mut c_void) };
         }
 
         for value in &self.values {
-            unsafe { CFRelease(*value as *mut libc::c_void) };
+            unsafe { CFRelease(*value as *mut c_void) };
         }
     }
 }
@@ -285,7 +285,7 @@ mod tests {
     use super::*;
     use core_foundation_sys::base::*;
     use core_foundation_sys::runloop::*;
-    use libc::c_void;
+    use std::os::raw::c_void;
     use std::ptr;
     use std::sync::mpsc::{channel, Sender};
     use std::thread;

--- a/src/macos/iokit.rs
+++ b/src/macos/iokit.rs
@@ -10,9 +10,11 @@ extern crate libc;
 use consts::{FIDO_USAGE_U2FHID, FIDO_USAGE_PAGE};
 use core_foundation_sys::base::*;
 use core_foundation_sys::dictionary::*;
-use core_foundation_sys::number::*;
 use core_foundation_sys::runloop::*;
 use core_foundation_sys::string::*;
+use core_foundation::dictionary::*;
+use core_foundation::string::*;
+use core_foundation::number::*;
 use std::os::raw::c_void;
 use std::ops::Deref;
 
@@ -152,76 +154,22 @@ impl Drop for CFRunLoopEntryObserver {
 }
 
 pub struct IOHIDDeviceMatcher {
-    dict: CFDictionaryRef,
-    keys: Vec<CFStringRef>,
-    values: Vec<CFNumberRef>,
+    pub dict: CFDictionary<CFString, CFNumber>,
 }
 
 impl IOHIDDeviceMatcher {
     pub fn new() -> Self {
-        let keys = vec![
-            IOHIDDeviceMatcher::cf_string("DeviceUsage"),
-            IOHIDDeviceMatcher::cf_string("DeviceUsagePage"),
-        ];
-
-        let values = vec![
-            IOHIDDeviceMatcher::cf_number(FIDO_USAGE_U2FHID as i32),
-            IOHIDDeviceMatcher::cf_number(FIDO_USAGE_PAGE as i32),
-        ];
-
-        let dict = unsafe {
-            CFDictionaryCreate(
-                kCFAllocatorDefault,
-                keys.as_ptr() as *const *const c_void,
-                values.as_ptr() as *const *const c_void,
-                keys.len() as CFIndex,
-                &kCFTypeDictionaryKeyCallBacks,
-                &kCFTypeDictionaryValueCallBacks,
-            )
-        };
-
-        Self { dict, keys, values }
-    }
-
-    fn cf_number(number: i32) -> CFNumberRef {
-        let nbox = Box::new(number);
-        let nptr = Box::into_raw(nbox) as *mut c_void;
-
-        unsafe {
-            // Drop when out of scope.
-            let _num = Box::from_raw(nptr as *mut i32);
-            CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, nptr)
-        }
-    }
-
-    fn cf_string(string: &str) -> CFStringRef {
-        unsafe {
-            CFStringCreateWithBytes(
-                kCFAllocatorDefault,
-                string.as_ptr(),
-                string.len() as CFIndex,
-                kCFStringEncodingUTF8,
-                false as Boolean,
-            )
-        }
-    }
-
-    pub fn get(&self) -> CFDictionaryRef {
-        self.dict
-    }
-}
-
-impl Drop for IOHIDDeviceMatcher {
-    fn drop(&mut self) {
-        unsafe { CFRelease(self.dict as *mut c_void) };
-
-        for key in &self.keys {
-            unsafe { CFRelease(*key as *mut c_void) };
-        }
-
-        for value in &self.values {
-            unsafe { CFRelease(*value as *mut c_void) };
-        }
+        let dict = CFDictionary::<CFString, CFNumber>::from_CFType_pairs(&[
+            (
+                CFString::from_static_string("DeviceUsage"),
+                CFNumber::from(FIDO_USAGE_U2FHID as i32),
+            ),
+            (
+                CFString::from_static_string("DeviceUsagePage"),
+                CFNumber::from(FIDO_USAGE_PAGE as i32),
+            ),
+            ]);
+        Self { dict }
     }
 }
 

--- a/src/macos/monitor.rs
+++ b/src/macos/monitor.rs
@@ -7,7 +7,7 @@ extern crate log;
 
 use core_foundation_sys::base::*;
 use core_foundation_sys::runloop::*;
-use libc::c_void;
+use std::os::raw::c_void;
 use platform::iokit::*;
 use runloop::RunLoop;
 use std::collections::HashMap;
@@ -170,6 +170,6 @@ where
     F: Fn((IOHIDDeviceRef, Receiver<Vec<u8>>), &Fn() -> bool) + Sync,
 {
     fn drop(&mut self) {
-        unsafe { CFRelease(self.manager as *mut libc::c_void) };
+        unsafe { CFRelease(self.manager as *mut c_void) };
     }
 }

--- a/src/macos/monitor.rs
+++ b/src/macos/monitor.rs
@@ -7,6 +7,7 @@ extern crate log;
 
 use core_foundation_sys::base::*;
 use core_foundation_sys::runloop::*;
+use core_foundation::base::TCFType;
 use std::os::raw::c_void;
 use platform::iokit::*;
 use runloop::RunLoop;
@@ -40,7 +41,7 @@ where
 
         // Match FIDO devices only.
         let _matcher = IOHIDDeviceMatcher::new();
-        unsafe { IOHIDManagerSetDeviceMatching(manager, _matcher.get()) };
+        unsafe { IOHIDManagerSetDeviceMatching(manager, _matcher.dict.as_concrete_TypeRef()) };
 
         Self {
             manager,

--- a/src/macos/transaction.rs
+++ b/src/macos/transaction.rs
@@ -5,7 +5,7 @@
 extern crate libc;
 
 use core_foundation_sys::runloop::*;
-use libc::c_void;
+use std::os::raw::c_void;
 use platform::iokit::{CFRunLoopEntryObserver, IOHIDDeviceRef, SendableRunLoop};
 use platform::monitor::Monitor;
 use std::sync::mpsc::{channel, Receiver, Sender};


### PR DESCRIPTION
This updates to core-foundation-sys 0.6.0 and additionally uses core-foundation to clean up some of the manual CFDictionary code.