### PR TITLE
Fix #65 - Update to WinAPI 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "u2fhid"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Kyle Machulis <kyle@nonpolynomial.com>", "J.C. Jones <jc@mozilla.com>", "Tim Taubert <ttaubert@mozilla.com>"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -13,8 +13,15 @@ devd-rs = "0.2.1"
 core-foundation-sys = "0.6.0"
 core-foundation = "0.6.0"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = "0.2.8"
+[target.'cfg(target_os = "windows")'.dependencies.winapi]
+version = "0.3"
+features = [
+    "handleapi",
+    "hidclass",
+    "hidpi",
+    "hidusage",
+    "setupapi",
+]
 
 [dependencies]
 rand = "0.3"

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -69,8 +69,7 @@ fn main() {
             move |rv| {
                 tx.send(rv.unwrap()).unwrap();
             },
-        )
-        .unwrap();
+        ).unwrap();
 
     let register_data = try_or!(rx.recv(), |_| {
         panic!("Problem receiving, unable to continue");
@@ -95,8 +94,7 @@ fn main() {
             move |rv| {
                 tx.send(rv.unwrap()).unwrap();
             },
-        )
-        .unwrap();
+        ).unwrap();
 
     let (_, handle_used, sign_data) = try_or!(rx.recv(), |_| {
         println!("Problem receiving");

--- a/src/freebsd/monitor.rs
+++ b/src/freebsd/monitor.rs
@@ -24,7 +24,8 @@ impl Event {
                 ref dev,
                 parent: _,
                 location: _,
-            } if dev.starts_with("uhid") =>
+            }
+                if dev.starts_with("uhid") =>
             {
                 Some(Event::Add(("/dev/".to_owned() + dev).into()))
             }
@@ -32,7 +33,8 @@ impl Event {
                 ref dev,
                 parent: _,
                 location: _,
-            } if dev.starts_with("uhid") =>
+            }
+                if dev.starts_with("uhid") =>
             {
                 Some(Event::Remove(("/dev/".to_owned() + dev).into()))
             }

--- a/src/hidproto.rs
+++ b/src/hidproto.rs
@@ -6,7 +6,7 @@
 
 use std::mem;
 
-use consts::{FIDO_USAGE_U2FHID, FIDO_USAGE_PAGE};
+use consts::{FIDO_USAGE_PAGE, FIDO_USAGE_U2FHID};
 
 // The 4 MSBs (the tag) are set when it's a long item.
 const HID_MASK_LONG_ITEM_TAG: u8 = 0b11110000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,12 @@ pub mod platform;
 #[path = "windows/mod.rs"]
 pub mod platform;
 
-#[cfg(
-    not(
-        any(target_os = "linux", target_os = "freebsd", target_os = "macos", target_os = "windows")
-    )
-)]
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "windows"
+)))]
 #[path = "stub/mod.rs"]
 pub mod platform;
 

--- a/src/macos/iokit.rs
+++ b/src/macos/iokit.rs
@@ -7,7 +7,7 @@
 extern crate core_foundation_sys;
 extern crate libc;
 
-use consts::{FIDO_USAGE_U2FHID, FIDO_USAGE_PAGE};
+use consts::{FIDO_USAGE_PAGE, FIDO_USAGE_U2FHID};
 use core_foundation::dictionary::*;
 use core_foundation::number::*;
 use core_foundation::string::*;

--- a/src/macos/transaction.rs
+++ b/src/macos/transaction.rs
@@ -57,8 +57,7 @@ impl Transaction {
 
                 // Send an error, if the callback wasn't called already.
                 callback.call(Err(::Error::NotAllowed));
-            })
-            .map_err(|_| ::Error::Unknown)?;
+            }).map_err(|_| ::Error::Unknown)?;
 
         // Block until we enter the CFRunLoop.
         let runloop = rx.recv().map_err(|_| ::Error::Unknown)?;

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -90,9 +90,12 @@ impl StateMachine {
             // If so, we'll keep polling the device anyway to test for user
             // consent, to be consistent with CTAP2 device behavior.
             let excluded = key_handles.iter().any(|key_handle| {
-                is_valid_transport(key_handle.transports)
-                    && u2f_is_keyhandle_valid(dev, &challenge, &application, &key_handle.credential)
-                        .unwrap_or(false) /* no match on failure */
+                is_valid_transport(key_handle.transports) && u2f_is_keyhandle_valid(
+                    dev,
+                    &challenge,
+                    &application,
+                    &key_handle.credential,
+                ).unwrap_or(false) /* no match on failure */
             });
 
             while alive() {

--- a/src/u2fprotocol.rs
+++ b/src/u2fprotocol.rs
@@ -215,7 +215,7 @@ mod tests {
     use rand::{thread_rng, Rng};
 
     use super::{init_device, send_apdu, sendrecv, U2FDevice};
-    use consts::{U2FHID_INIT, U2FHID_MSG, U2FHID_PING, CID_BROADCAST, SW_NO_ERROR};
+    use consts::{CID_BROADCAST, SW_NO_ERROR, U2FHID_INIT, U2FHID_MSG, U2FHID_PING};
 
     mod platform {
         use std::io;

--- a/src/windows/device.rs
+++ b/src/windows/device.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use std::os::windows::io::AsRawHandle;
 
 use super::winapi::DeviceCapabilities;
-use consts::{FIDO_USAGE_U2FHID, CID_BROADCAST, FIDO_USAGE_PAGE, HID_RPT_SIZE};
+use consts::{CID_BROADCAST, FIDO_USAGE_PAGE, FIDO_USAGE_U2FHID, HID_RPT_SIZE};
 
 use u2ftypes::U2FDevice;
 

--- a/src/windows/winapi.rs
+++ b/src/windows/winapi.rs
@@ -15,8 +15,8 @@ use util::io_err;
 extern crate libc;
 extern crate winapi;
 
-use platform::winapi::winapi::shared::{hidclass, hidpi, hidusage};
 use platform::winapi::winapi::shared::{guiddef, minwindef, ntdef, windef};
+use platform::winapi::winapi::shared::{hidclass, hidpi, hidusage};
 use platform::winapi::winapi::um::{handleapi, setupapi};
 
 #[link(name = "setupapi")]
@@ -57,7 +57,10 @@ extern "stdcall" {
 
     fn HidD_FreePreparsedData(PreparsedData: hidpi::PHIDP_PREPARSED_DATA) -> ntdef::BOOLEAN;
 
-    fn HidP_GetCaps(PreparsedData: hidpi::PHIDP_PREPARSED_DATA, Capabilities: hidpi::PHIDP_CAPS) -> ntdef::NTSTATUS;
+    fn HidP_GetCaps(
+        PreparsedData: hidpi::PHIDP_PREPARSED_DATA,
+        Capabilities: hidpi::PHIDP_CAPS,
+    ) -> ntdef::NTSTATUS;
 }
 
 macro_rules! offset_of {
@@ -124,8 +127,10 @@ impl<'a> Iterator for DeviceInfoSetIter<'a> {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut device_interface_data = unsafe { mem::uninitialized::<setupapi::SP_DEVICE_INTERFACE_DATA>() };
-        device_interface_data.cbSize = mem::size_of::<setupapi::SP_DEVICE_INTERFACE_DATA>() as minwindef::UINT;
+        let mut device_interface_data =
+            unsafe { mem::uninitialized::<setupapi::SP_DEVICE_INTERFACE_DATA>() };
+        device_interface_data.cbSize =
+            mem::size_of::<setupapi::SP_DEVICE_INTERFACE_DATA>() as minwindef::UINT;
 
         let rv = unsafe {
             SetupDiEnumDeviceInterfaces(

--- a/src/windows/winapi.rs
+++ b/src/windows/winapi.rs
@@ -14,47 +14,50 @@ use util::io_err;
 
 extern crate libc;
 extern crate winapi;
-use self::winapi::*;
+
+use platform::winapi::winapi::shared::{hidclass, hidpi, hidusage};
+use platform::winapi::winapi::shared::{guiddef, minwindef, ntdef, windef};
+use platform::winapi::winapi::um::{handleapi, setupapi};
 
 #[link(name = "setupapi")]
 extern "stdcall" {
     fn SetupDiGetClassDevsW(
-        ClassGuid: *const GUID,
-        Enumerator: PCSTR,
-        hwndParent: HWND,
-        flags: DWORD,
-    ) -> HDEVINFO;
+        ClassGuid: *const guiddef::GUID,
+        Enumerator: ntdef::PCSTR,
+        hwndParent: windef::HWND,
+        flags: minwindef::DWORD,
+    ) -> setupapi::HDEVINFO;
 
-    fn SetupDiDestroyDeviceInfoList(DeviceInfoSet: HDEVINFO) -> BOOL;
+    fn SetupDiDestroyDeviceInfoList(DeviceInfoSet: setupapi::HDEVINFO) -> minwindef::BOOL;
 
     fn SetupDiEnumDeviceInterfaces(
-        DeviceInfoSet: HDEVINFO,
-        DeviceInfoData: PSP_DEVINFO_DATA,
-        InterfaceClassGuid: *const GUID,
-        MemberIndex: DWORD,
-        DeviceInterfaceData: PSP_DEVICE_INTERFACE_DATA,
-    ) -> BOOL;
+        DeviceInfoSet: setupapi::HDEVINFO,
+        DeviceInfoData: setupapi::PSP_DEVINFO_DATA,
+        InterfaceClassGuid: *const guiddef::GUID,
+        MemberIndex: minwindef::DWORD,
+        DeviceInterfaceData: setupapi::PSP_DEVICE_INTERFACE_DATA,
+    ) -> minwindef::BOOL;
 
     fn SetupDiGetDeviceInterfaceDetailW(
-        DeviceInfoSet: HDEVINFO,
-        DeviceInterfaceData: PSP_DEVICE_INTERFACE_DATA,
-        DeviceInterfaceDetailData: PSP_DEVICE_INTERFACE_DETAIL_DATA_W,
-        DeviceInterfaceDetailDataSize: DWORD,
-        RequiredSize: PDWORD,
-        DeviceInfoData: PSP_DEVINFO_DATA,
-    ) -> BOOL;
+        DeviceInfoSet: setupapi::HDEVINFO,
+        DeviceInterfaceData: setupapi::PSP_DEVICE_INTERFACE_DATA,
+        DeviceInterfaceDetailData: setupapi::PSP_DEVICE_INTERFACE_DETAIL_DATA_W,
+        DeviceInterfaceDetailDataSize: minwindef::DWORD,
+        RequiredSize: minwindef::PDWORD,
+        DeviceInfoData: setupapi::PSP_DEVINFO_DATA,
+    ) -> minwindef::BOOL;
 }
 
 #[link(name = "hid")]
 extern "stdcall" {
     fn HidD_GetPreparsedData(
-        HidDeviceObject: HANDLE,
-        PreparsedData: *mut PHIDP_PREPARSED_DATA,
-    ) -> BOOLEAN;
+        HidDeviceObject: ntdef::HANDLE,
+        PreparsedData: *mut hidpi::PHIDP_PREPARSED_DATA,
+    ) -> ntdef::BOOLEAN;
 
-    fn HidD_FreePreparsedData(PreparsedData: PHIDP_PREPARSED_DATA) -> BOOLEAN;
+    fn HidD_FreePreparsedData(PreparsedData: hidpi::PHIDP_PREPARSED_DATA) -> ntdef::BOOLEAN;
 
-    fn HidP_GetCaps(PreparsedData: PHIDP_PREPARSED_DATA, Capabilities: PHIDP_CAPS) -> NTSTATUS;
+    fn HidP_GetCaps(PreparsedData: hidpi::PHIDP_PREPARSED_DATA, Capabilities: hidpi::PHIDP_CAPS) -> ntdef::NTSTATUS;
 }
 
 macro_rules! offset_of {
@@ -70,28 +73,28 @@ fn from_wide_ptr(ptr: *const u16, len: usize) -> String {
 }
 
 pub struct DeviceInfoSet {
-    set: HDEVINFO,
+    set: setupapi::HDEVINFO,
 }
 
 impl DeviceInfoSet {
     pub fn new() -> io::Result<Self> {
-        let flags = DIGCF_PRESENT | DIGCF_DEVICEINTERFACE;
+        let flags = setupapi::DIGCF_PRESENT | setupapi::DIGCF_DEVICEINTERFACE;
         let set = unsafe {
             SetupDiGetClassDevsW(
-                &GUID_DEVINTERFACE_HID,
+                &hidclass::GUID_DEVINTERFACE_HID,
                 ptr::null_mut(),
                 ptr::null_mut(),
                 flags,
             )
         };
-        if set == INVALID_HANDLE_VALUE {
+        if set == handleapi::INVALID_HANDLE_VALUE {
             return Err(io_err("SetupDiGetClassDevsW failed!"));
         }
 
         Ok(Self { set })
     }
 
-    pub fn get(&self) -> HDEVINFO {
+    pub fn get(&self) -> setupapi::HDEVINFO {
         self.set
     }
 
@@ -108,7 +111,7 @@ impl Drop for DeviceInfoSet {
 
 pub struct DeviceInfoSetIter<'a> {
     set: &'a DeviceInfoSet,
-    index: DWORD,
+    index: minwindef::DWORD,
 }
 
 impl<'a> DeviceInfoSetIter<'a> {
@@ -121,14 +124,14 @@ impl<'a> Iterator for DeviceInfoSetIter<'a> {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut device_interface_data = unsafe { mem::uninitialized::<SP_DEVICE_INTERFACE_DATA>() };
-        device_interface_data.cbSize = mem::size_of::<SP_DEVICE_INTERFACE_DATA>() as UINT;
+        let mut device_interface_data = unsafe { mem::uninitialized::<setupapi::SP_DEVICE_INTERFACE_DATA>() };
+        device_interface_data.cbSize = mem::size_of::<setupapi::SP_DEVICE_INTERFACE_DATA>() as minwindef::UINT;
 
         let rv = unsafe {
             SetupDiEnumDeviceInterfaces(
                 self.set.get(),
                 ptr::null_mut(),
-                &GUID_DEVINTERFACE_HID,
+                &hidclass::GUID_DEVINTERFACE_HID,
                 self.index,
                 &mut device_interface_data,
             )
@@ -179,13 +182,13 @@ impl<'a> Iterator for DeviceInfoSetIter<'a> {
 }
 
 struct DeviceInterfaceDetailData {
-    data: PSP_DEVICE_INTERFACE_DETAIL_DATA_W,
+    data: setupapi::PSP_DEVICE_INTERFACE_DETAIL_DATA_W,
     path_len: usize,
 }
 
 impl DeviceInterfaceDetailData {
     fn new(size: usize) -> Option<Self> {
-        let mut cb_size = mem::size_of::<SP_DEVICE_INTERFACE_DETAIL_DATA_W>();
+        let mut cb_size = mem::size_of::<setupapi::SP_DEVICE_INTERFACE_DETAIL_DATA_W>();
         if cfg!(target_pointer_width = "32") {
             cb_size = 4 + 2; // 4-byte uint + default TCHAR size. size_of is inaccurate.
         }
@@ -195,16 +198,16 @@ impl DeviceInterfaceDetailData {
             return None;
         }
 
-        let data = unsafe { libc::malloc(size) as PSP_DEVICE_INTERFACE_DETAIL_DATA_W };
+        let data = unsafe { libc::malloc(size) as setupapi::PSP_DEVICE_INTERFACE_DETAIL_DATA_W };
         if data.is_null() {
             return None;
         }
 
         // Set total size of the structure.
-        unsafe { (*data).cbSize = cb_size as UINT };
+        unsafe { (*data).cbSize = cb_size as minwindef::UINT };
 
         // Compute offset of `SP_DEVICE_INTERFACE_DETAIL_DATA_W.DevicePath`.
-        let offset = offset_of!(SP_DEVICE_INTERFACE_DETAIL_DATA_W, DevicePath);
+        let offset = offset_of!(setupapi::SP_DEVICE_INTERFACE_DETAIL_DATA_W, DevicePath);
 
         Some(Self {
             data,
@@ -212,7 +215,7 @@ impl DeviceInterfaceDetailData {
         })
     }
 
-    fn get(&self) -> PSP_DEVICE_INTERFACE_DETAIL_DATA_W {
+    fn get(&self) -> setupapi::PSP_DEVICE_INTERFACE_DETAIL_DATA_W {
         self.data
     }
 
@@ -228,24 +231,24 @@ impl Drop for DeviceInterfaceDetailData {
 }
 
 pub struct DeviceCapabilities {
-    caps: HIDP_CAPS,
+    caps: hidpi::HIDP_CAPS,
 }
 
 impl DeviceCapabilities {
-    pub fn new(handle: HANDLE) -> io::Result<Self> {
+    pub fn new(handle: ntdef::HANDLE) -> io::Result<Self> {
         let mut preparsed_data = ptr::null_mut();
         let rv = unsafe { HidD_GetPreparsedData(handle, &mut preparsed_data) };
         if rv == 0 || preparsed_data.is_null() {
             return Err(io_err("HidD_GetPreparsedData failed!"));
         }
 
-        let mut caps: HIDP_CAPS = unsafe { mem::uninitialized() };
+        let mut caps: hidpi::HIDP_CAPS = unsafe { mem::uninitialized() };
 
         unsafe {
             let rv = HidP_GetCaps(preparsed_data, &mut caps);
             HidD_FreePreparsedData(preparsed_data);
 
-            if rv != HIDP_STATUS_SUCCESS {
+            if rv != hidpi::HIDP_STATUS_SUCCESS {
                 return Err(io_err("HidP_GetCaps failed!"));
             }
         }
@@ -253,11 +256,11 @@ impl DeviceCapabilities {
         Ok(Self { caps })
     }
 
-    pub fn usage(&self) -> USAGE {
+    pub fn usage(&self) -> hidusage::USAGE {
         self.caps.Usage
     }
 
-    pub fn usage_page(&self) -> USAGE {
+    pub fn usage_page(&self) -> hidusage::USAGE {
         self.caps.UsagePage
     }
 }


### PR DESCRIPTION
This updates to the new package layouts for the WinAPI 0.3.x crate, which doesn't appear to have had any semantic changes over 0.2.x.