### PR TITLE
use `extern "system"` rather than `extern "stdcall"`

### DIFF
--- a/src/windows/winapi.rs
+++ b/src/windows/winapi.rs
@@ -20,7 +20,7 @@ use platform::winapi::winapi::shared::{hidclass, hidpi, hidusage};
 use platform::winapi::winapi::um::{handleapi, setupapi};
 
 #[link(name = "setupapi")]
-extern "stdcall" {
+extern "system" {
     fn SetupDiGetClassDevsW(
         ClassGuid: *const guiddef::GUID,
         Enumerator: ntdef::PCSTR,
@@ -49,7 +49,7 @@ extern "stdcall" {
 }
 
 #[link(name = "hid")]
-extern "stdcall" {
+extern "system" {
     fn HidD_GetPreparsedData(
         HidDeviceObject: ntdef::HANDLE,
         PreparsedData: *mut hidpi::PHIDP_PREPARSED_DATA,


### PR DESCRIPTION
`extern "stdcall"` really only has meaning on x86 Windows; I'm not even sure what calling `extern "stdcall"` functions on x86-64 Windows does (probably bad things?).  `extern "system"` carries the correct meaning on x86 and x86-64 (and other architectures such as AArch64), so let's use that.  (FWIW, `winapi` also uses `extern "system"` for these functions.)