### PR TITLE
Fix #35 - Run Clippy at TravisCI, and clean up Clippy warnings

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+type-complexity-threshold = 384

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /target/
 **/*.rs.bk
 
+# Fuzzing corpuses should be explicitly updated
+fuzz/corpus/
+
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 install:
   - rustup install nightly
   - rustup component add rustfmt-preview
+  - rustup component add clippy-preview
 
 script:
 - |
@@ -35,5 +36,5 @@ script:
   if [ "$TRAVIS_RUST_VERSION" == "stable" ] ; then
     cargo fmt --all -- --check
   fi
-- cargo build
+- cargo clippy --all-targets -- -A renamed_and_removed_lints -A new-ret-no-self -D warnings
 - cargo test

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -24,7 +24,7 @@ macro_rules! try_or {
     };
 }
 
-fn u2f_get_key_handle_from_register_response(register_response: &Vec<u8>) -> io::Result<Vec<u8>> {
+fn u2f_get_key_handle_from_register_response(register_response: &[u8]) -> io::Result<Vec<u8>> {
     if register_response[0] != 0x05 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -33,7 +33,7 @@ fn u2f_get_key_handle_from_register_response(register_response: &Vec<u8>) -> io:
     }
 
     let key_handle_len = register_response[66] as usize;
-    let mut public_key = register_response.clone();
+    let mut public_key = register_response.to_owned();
     let mut key_handle = public_key.split_off(67);
     let _attestation = key_handle.split_off(key_handle_len);
 

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn rust_u2f_result_error(res: *const U2FResult) -> u8 {
         return *err as u8;
     }
 
-    return 0; /* No error, the request succeeded. */
+    0 /* No error, the request succeeded. */
 }
 
 #[no_mangle]
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn rust_u2f_mgr_sign(
     }
 
     // Need at least one app_id.
-    if (*app_ids).len() < 1 {
+    if (*app_ids).is_empty() {
         return 0;
     }
 

--- a/src/linux/device.rs
+++ b/src/linux/device.rs
@@ -73,7 +73,7 @@ impl Write for Device {
 }
 
 impl U2FDevice for Device {
-    fn get_cid<'a>(&'a self) -> &'a [u8; 4] {
+    fn get_cid(&self) -> &[u8; 4] {
         &self.cid
     }
 

--- a/src/linux/hidraw.rs
+++ b/src/linux/hidraw.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
 
 extern crate libc;
 

--- a/src/linux/monitor.rs
+++ b/src/linux/monitor.rs
@@ -12,7 +12,7 @@ use std::io;
 use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
 
-const UDEV_SUBSYSTEM: &'static str = "hidraw";
+const UDEV_SUBSYSTEM: &str = "hidraw";
 const POLLIN: c_short = 0x0001;
 const POLL_TIMEOUT: c_int = 100;
 
@@ -76,7 +76,7 @@ where
             poll(&mut fds)?;
 
             if let Some(event) = socket.receive_event() {
-                self.process_event(event);
+                self.process_event(&event);
             }
         }
 
@@ -86,7 +86,7 @@ where
         Ok(())
     }
 
-    fn process_event(&mut self, event: libudev::Event) {
+    fn process_event(&mut self, event: &libudev::Event) {
         let path = event
             .device()
             .devnode()
@@ -97,7 +97,7 @@ where
                 self.add_device(path);
             }
             (EventType::Remove, Some(path)) => {
-                self.remove_device(path);
+                self.remove_device(&path);
             }
             _ => { /* ignore other types and failures */ }
         }
@@ -118,8 +118,8 @@ where
         }
     }
 
-    fn remove_device(&mut self, path: OsString) {
-        if let Some(runloop) = self.runloops.remove(&path) {
+    fn remove_device(&mut self, path: &OsString) {
+        if let Some(runloop) = self.runloops.remove(path) {
             runloop.cancel();
         }
     }
@@ -127,7 +127,7 @@ where
     fn remove_all_devices(&mut self) {
         while !self.runloops.is_empty() {
             let path = self.runloops.keys().next().unwrap().clone();
-            self.remove_device(path);
+            self.remove_device(&path);
         }
     }
 }

--- a/src/macos/device.rs
+++ b/src/macos/device.rs
@@ -62,7 +62,7 @@ impl Write for Device {
     fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
         assert_eq!(bytes.len(), HID_RPT_SIZE + 1);
 
-        let report_id = bytes[0] as i64;
+        let report_id = i64::from(bytes[0]);
         // Skip report number when not using numbered reports.
         let start = if report_id == 0x0 { 1 } else { 0 };
         let data = &bytes[start..];

--- a/src/macos/iokit.rs
+++ b/src/macos/iokit.rs
@@ -160,11 +160,11 @@ impl IOHIDDeviceMatcher {
         let dict = CFDictionary::<CFString, CFNumber>::from_CFType_pairs(&[
             (
                 CFString::from_static_string("DeviceUsage"),
-                CFNumber::from(FIDO_USAGE_U2FHID as i32),
+                CFNumber::from(i32::from(FIDO_USAGE_U2FHID)),
             ),
             (
                 CFString::from_static_string("DeviceUsagePage"),
-                CFNumber::from(FIDO_USAGE_PAGE as i32),
+                CFNumber::from(i32::from(FIDO_USAGE_PAGE)),
             ),
         ]);
         Self { dict }

--- a/src/macos/monitor.rs
+++ b/src/macos/monitor.rs
@@ -90,15 +90,15 @@ where
         // Remove all devices.
         while !self.map.is_empty() {
             let device_ref = *self.map.keys().next().unwrap();
-            self.remove_device(&device_ref);
+            self.remove_device(device_ref);
         }
 
         // Close the manager and its devices.
         unsafe { IOHIDManagerClose(self.manager, kIOHIDManagerOptionNone) };
     }
 
-    fn remove_device(&mut self, device_ref: &IOHIDDeviceRef) {
-        if let Some(DeviceData { tx, runloop }) = self.map.remove(device_ref) {
+    fn remove_device(&mut self, device_ref: IOHIDDeviceRef) {
+        if let Some(DeviceData { tx, runloop }) = self.map.remove(&device_ref) {
             // Dropping `tx` will make Device::read() fail eventually.
             drop(tx);
 
@@ -127,7 +127,7 @@ where
 
         // Remove the device if sending fails.
         if send_failed {
-            this.remove_device(&device_ref);
+            this.remove_device(device_ref);
         }
     }
 
@@ -162,7 +162,7 @@ where
         device_ref: IOHIDDeviceRef,
     ) {
         let this = unsafe { &mut *(context as *mut Self) };
-        this.remove_device(&device_ref);
+        this.remove_device(device_ref);
     }
 }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -91,10 +91,7 @@ impl U2FManager {
             sm.cancel();
         })?;
 
-        Ok(Self {
-            queue: queue,
-            tx: tx,
-        })
+        Ok(Self { queue, tx })
     }
 
     pub fn register<F>(
@@ -149,7 +146,7 @@ impl U2FManager {
             return Err(::Error::Unknown);
         }
 
-        if app_ids.len() < 1 {
+        if app_ids.is_empty() {
             return Err(::Error::Unknown);
         }
 

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -15,8 +15,8 @@ fn is_valid_transport(transports: ::AuthenticatorTransports) -> bool {
 }
 
 fn find_valid_key_handles<'a, F>(
-    app_ids: &'a Vec<::AppId>,
-    key_handles: &'a Vec<::KeyHandle>,
+    app_ids: &'a [::AppId],
+    key_handles: &'a [::KeyHandle],
     mut is_valid: F,
 ) -> (&'a ::AppId, Vec<&'a ::KeyHandle>)
 where
@@ -31,12 +31,12 @@ where
             .collect::<Vec<_>>();
 
         // If there's at least one, stop.
-        if valid_handles.len() > 0 {
+        if !valid_handles.is_empty() {
             return (app_id, valid_handles);
         }
     }
 
-    return (&app_ids[0], vec![]);
+    (&app_ids[0], vec![])
 }
 
 #[derive(Default)]
@@ -101,15 +101,13 @@ impl StateMachine {
             while alive() {
                 if excluded {
                     let blank = vec![0u8; PARAMETER_SIZE];
-                    if let Ok(_) = u2f_register(dev, &blank, &blank) {
+                    if u2f_register(dev, &blank, &blank).is_ok() {
                         callback.call(Err(::Error::InvalidState));
                         break;
                     }
-                } else {
-                    if let Ok(bytes) = u2f_register(dev, &challenge, &application) {
-                        callback.call(Ok(bytes));
-                        break;
-                    }
+                } else if let Ok(bytes) = u2f_register(dev, &challenge, &application) {
+                    callback.call(Ok(bytes));
+                    break;
                 }
 
                 // Sleep a bit before trying again.
@@ -181,7 +179,7 @@ impl StateMachine {
                 // then just make it blink with bogus data.
                 if valid_handles.is_empty() {
                     let blank = vec![0u8; PARAMETER_SIZE];
-                    if let Ok(_) = u2f_register(dev, &blank, &blank) {
+                    if u2f_register(dev, &blank, &blank).is_ok() {
                         callback.call(Err(::Error::InvalidState));
                         break;
                     }

--- a/src/u2ftypes.rs
+++ b/src/u2ftypes.rs
@@ -167,7 +167,7 @@ impl U2FHIDInitResp {
 pub struct U2FAPDUHeader {}
 
 impl U2FAPDUHeader {
-    pub fn to_bytes(ins: u8, p1: u8, data: &[u8]) -> io::Result<Vec<u8>> {
+    pub fn serialize(ins: u8, p1: u8, data: &[u8]) -> io::Result<Vec<u8>> {
         if data.len() > 0xffff {
             return Err(io_err("payload length > 2^16"));
         }


### PR DESCRIPTION
This works for Rust Beta and Stable, and breaks on Nightly because the clippy lints require a `clippy::` prefix. Eventually that will break Rust Beta builds at which case we'll need to adjust the `.travis.yml` again.

Lots of this is taken from https://github.com/serianox/u2f-hid-rs/tree/ci -- thanks @serianox!