### PR TITLE
Fix #60 - Only use core-foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ libudev = "^0.2"
 devd-rs = "0.2.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation-sys = "0.6.0"
-core-foundation = "0.6.0"
+core-foundation = "0.6.2"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,6 @@ extern crate devd_rs;
 pub mod platform;
 
 #[cfg(any(target_os = "macos"))]
-extern crate core_foundation_sys;
-
-#[cfg(any(target_os = "macos"))]
 extern crate core_foundation;
 
 #[cfg(any(target_os = "macos"))]

--- a/src/macos/device.rs
+++ b/src/macos/device.rs
@@ -5,7 +5,7 @@
 extern crate log;
 
 use consts::{CID_BROADCAST, HID_RPT_SIZE};
-use core_foundation_sys::base::*;
+use core_foundation::base::*;
 use platform::iokit::*;
 use std::io;
 use std::io::{Read, Write};

--- a/src/macos/iokit.rs
+++ b/src/macos/iokit.rs
@@ -4,15 +4,15 @@
 
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
-extern crate core_foundation_sys;
 extern crate libc;
 
 use consts::{FIDO_USAGE_PAGE, FIDO_USAGE_U2FHID};
+use core_foundation::array::*;
+use core_foundation::base::*;
 use core_foundation::dictionary::*;
 use core_foundation::number::*;
+use core_foundation::runloop::*;
 use core_foundation::string::*;
-use core_foundation_sys::base::*;
-use core_foundation_sys::runloop::*;
 use std::ops::Deref;
 use std::os::raw::c_void;
 

--- a/src/macos/monitor.rs
+++ b/src/macos/monitor.rs
@@ -5,9 +5,8 @@
 extern crate libc;
 extern crate log;
 
-use core_foundation::base::TCFType;
-use core_foundation_sys::base::*;
-use core_foundation_sys::runloop::*;
+use core_foundation::base::*;
+use core_foundation::runloop::*;
 use platform::iokit::*;
 use runloop::RunLoop;
 use std::collections::HashMap;

--- a/src/macos/transaction.rs
+++ b/src/macos/transaction.rs
@@ -4,7 +4,7 @@
 
 extern crate libc;
 
-use core_foundation_sys::runloop::*;
+use core_foundation::runloop::*;
 use platform::iokit::{CFRunLoopEntryObserver, IOHIDDeviceRef, SendableRunLoop};
 use platform::monitor::Monitor;
 use std::os::raw::c_void;


### PR DESCRIPTION
Earlier versions of `core-foundation` lacked `runloop` support, among other things, prompting us to use `core-foundation-sys`. >0.6 supports everything needed out of `-sys`, so let's retire direct use of `core-foundation-sys`.