### PR TITLE
Allow disabling C API exports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ travis-ci = { repository = "mozilla/authenticator-rs", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [features]
+default = ["c-api"]
+c-api = []
 binding-recompile = ["bindgen"]
 webdriver = ["base64", "bytes", "warp", "tokio", "serde", "serde_json"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,9 @@ mod u2ftypes;
 mod manager;
 pub use crate::manager::U2FManager;
 
+#[cfg(feature = "c-api")]
 mod capi;
+#[cfg(feature = "c-api")]
 pub use crate::capi::*;
 
 pub mod errors;


### PR DESCRIPTION
This PR allows downstream users to disable the compilation of the C API exposed by `authenticator`. These may not be used by pure Rust projects and the inclusion of them causes unneeded noise in some crash/stack backtraces.

The exposure of these was moved behind a feature flag to solve this problem. It is enabled by default to remain compatible with anyone who may have been relying on them.