### PR TITLE
Fix #216: Correctly parse device-properties for Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ crypto_nss = ["nss-gk-api", "pkcs11-bindings"]
 gecko = ["nss-gk-api/gecko"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libudev = "^0.2"
+libudev = "^0.3"
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
 devd-rs = "0.3"


### PR DESCRIPTION
This needs to bump libudev, because the API had a bug that disallowed iterating the device tree.

Vendoring in Firefox is not a problem, since libudev is only used by auth-rs.
We need, however, to add 3 or 4 function definitions to `dom/webauthn/libudev-sys/lib.rs`.

If we don't want to do this yet, this PR can just stay pending, since the info is not really used currently (except for some output in the examples).