### PR TITLE
Add interactive token management functionality

### DIFF
--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -84,6 +84,9 @@ fn main() {
     let (status_tx, status_rx) = channel::<StatusUpdate>();
     thread::spawn(move || loop {
         match status_rx.recv() {
+            Ok(StatusUpdate::InteractiveManagement(..)) => {
+                panic!("STATUS: This can't happen when doing non-interactive usage");
+            }
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
                 println!("STATUS: device available: {dev_info}")
             }

--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -47,6 +47,9 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
     let (status_tx, status_rx) = channel::<StatusUpdate>();
     thread::spawn(move || loop {
         match status_rx.recv() {
+            Ok(StatusUpdate::InteractiveManagement(..)) => {
+                panic!("STATUS: This can't happen when doing non-interactive usage");
+            }
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
                 println!("STATUS: device available: {dev_info}")
             }
@@ -237,6 +240,9 @@ fn main() {
     let (status_tx, status_rx) = channel::<StatusUpdate>();
     thread::spawn(move || loop {
         match status_rx.recv() {
+            Ok(StatusUpdate::InteractiveManagement(..)) => {
+                panic!("STATUS: This can't happen when doing non-interactive usage");
+            }
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
                 println!("STATUS: device available: {dev_info}")
             }

--- a/examples/interactive_management.rs
+++ b/examples/interactive_management.rs
@@ -1,0 +1,201 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use authenticator::{
+    authenticatorservice::AuthenticatorService, errors::AuthenticatorError,
+    statecallback::StateCallback, InteractiveRequest, Pin, ResetResult, StatusUpdate,
+};
+use getopts::Options;
+use log::debug;
+use std::{env, io, thread};
+use std::{
+    io::Write,
+    sync::mpsc::{channel, Receiver, RecvError},
+};
+
+fn print_usage(program: &str, opts: Options) {
+    let brief = format!("Usage: {program} [options]");
+    print!("{}", opts.usage(&brief));
+}
+
+fn interactive_status_callback(status_rx: Receiver<StatusUpdate>) {
+    let mut num_of_devices = 0;
+    loop {
+        match status_rx.recv() {
+            Ok(StatusUpdate::InteractiveManagement((tx, dev_info, auth_info))) => {
+                debug!(
+                    "STATUS: interactive management: {:#}, {:#?}",
+                    dev_info, auth_info
+                );
+                println!("Device info {:#}", dev_info);
+                let mut change_pin = false;
+                if let Some(info) = auth_info {
+                    println!("Authenticator Info {:#?}", info);
+                    println!();
+                    println!("What do you wish to do?");
+
+                    let mut choices = vec!["0", "1"];
+                    println!("(0) Quit");
+                    println!("(1) Reset token");
+                    match info.options.client_pin {
+                        None => {}
+                        Some(true) => {
+                            println!("(2) Change PIN");
+                            choices.push("2");
+                            change_pin = true;
+                        }
+                        Some(false) => {
+                            println!("(2) Set PIN");
+                            choices.push("2");
+                        }
+                    }
+
+                    let mut input = String::new();
+                    while !choices.contains(&input.trim()) {
+                        input.clear();
+                        print!("Your choice: ");
+                        io::stdout()
+                            .lock()
+                            .flush()
+                            .expect("Failed to flush stdout!");
+                        io::stdin()
+                            .read_line(&mut input)
+                            .expect("error: unable to read user input");
+                    }
+                    input = input.trim().to_string();
+
+                    match input.as_str() {
+                        "0" => {
+                            return;
+                        }
+                        "1" => {
+                            tx.send(InteractiveRequest::Reset)
+                                .expect("Failed to send Reset request.");
+                        }
+                        "2" => {
+                            let raw_new_pin = rpassword::prompt_password_stderr("Enter new PIN: ")
+                                .expect("Failed to read PIN");
+                            let new_pin = Pin::new(&raw_new_pin);
+                            if change_pin {
+                                let raw_curr_pin =
+                                    rpassword::prompt_password_stderr("Enter current PIN: ")
+                                        .expect("Failed to read PIN");
+                                let curr_pin = Pin::new(&raw_curr_pin);
+                                tx.send(InteractiveRequest::ChangePIN(curr_pin, new_pin))
+                                    .expect("Failed to send PIN-change request");
+                            } else {
+                                tx.send(InteractiveRequest::SetPIN(new_pin))
+                                    .expect("Failed to send PIN-set request");
+                            }
+                            return;
+                        }
+                        _ => {
+                            panic!("Can't happen");
+                        }
+                    }
+                } else {
+                    println!("Device only supports CTAP1 and can't be managed.");
+                }
+            }
+            Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
+                num_of_devices += 1;
+                debug!(
+                    "STATUS: New device #{} available: {}",
+                    num_of_devices, dev_info
+                );
+            }
+            Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
+                num_of_devices -= 1;
+                if num_of_devices <= 0 {
+                    println!("No more devices left. Please plug in a device!");
+                }
+                debug!("STATUS: Device became unavailable: {}", dev_info)
+            }
+            Ok(StatusUpdate::Success { dev_info }) => {
+                println!("STATUS: success using device: {}", dev_info);
+            }
+            Ok(StatusUpdate::SelectDeviceNotice) => {
+                println!("STATUS: Please select a device by touching one of them.");
+            }
+            Ok(StatusUpdate::DeviceSelected(_dev_info)) => {}
+            Ok(StatusUpdate::PinUvError(..)) => {
+                println!("STATUS: Pin Error!");
+            }
+            Err(RecvError) => {
+                println!("STATUS: end");
+                return;
+            }
+        }
+    }
+}
+
+fn main() {
+    env_logger::init();
+
+    let args: Vec<String> = env::args().collect();
+    let program = args[0].clone();
+
+    let mut opts = Options::new();
+    opts.optflag("x", "no-u2f-usb-hid", "do not enable u2f-usb-hid platforms");
+    opts.optflag("h", "help", "print this help menu").optopt(
+        "t",
+        "timeout",
+        "timeout in seconds",
+        "SEC",
+    );
+    opts.optflag("h", "help", "print this help menu");
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(f) => panic!("{}", f.to_string()),
+    };
+    if matches.opt_present("help") {
+        print_usage(&program, opts);
+        return;
+    }
+
+    let mut manager =
+        AuthenticatorService::new().expect("The auth service should initialize safely");
+
+    if !matches.opt_present("no-u2f-usb-hid") {
+        manager.add_u2f_usb_hid_platform_transports();
+    }
+
+    let timeout_ms = match matches.opt_get_default::<u64>("timeout", 120) {
+        Ok(timeout_s) => {
+            println!("Using {}s as the timeout", &timeout_s);
+            timeout_s * 1_000
+        }
+        Err(e) => {
+            println!("{e}");
+            print_usage(&program, opts);
+            return;
+        }
+    };
+
+    let (status_tx, status_rx) = channel::<StatusUpdate>();
+    thread::spawn(move || interactive_status_callback(status_rx));
+
+    let (manage_tx, manage_rx) = channel();
+    let state_callback =
+        StateCallback::<Result<ResetResult, AuthenticatorError>>::new(Box::new(move |rv| {
+            manage_tx.send(rv).unwrap();
+        }));
+
+    match manager.manage(timeout_ms, status_tx, state_callback) {
+        Ok(_) => {
+            debug!("Started management")
+        }
+        Err(e) => {
+            println!("Error! Failed to start interactive management: {:?}", e)
+        }
+    }
+    let manage_result = manage_rx
+        .recv()
+        .expect("Problem receiving, unable to continue");
+    match manage_result {
+        Ok(_) => println!("Success!"),
+        Err(e) => println!("Error! {:?}", e),
+    };
+    println!("Done");
+}

--- a/examples/set_pin.rs
+++ b/examples/set_pin.rs
@@ -70,6 +70,9 @@ fn main() {
     let (status_tx, status_rx) = channel::<StatusUpdate>();
     thread::spawn(move || loop {
         match status_rx.recv() {
+            Ok(StatusUpdate::InteractiveManagement(..)) => {
+                panic!("STATUS: This can't happen when doing non-interactive usage");
+            }
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
                 println!("STATUS: device available: {dev_info}")
             }

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -77,6 +77,9 @@ fn main() {
     let (status_tx, status_rx) = channel::<StatusUpdate>();
     thread::spawn(move || loop {
         match status_rx.recv() {
+            Ok(StatusUpdate::InteractiveManagement(..)) => {
+                panic!("STATUS: This can't happen when doing non-interactive usage");
+            }
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
                 println!("STATUS: device available: {dev_info}")
             }

--- a/src/ctap2/commands/client_pin.rs
+++ b/src/ctap2/commands/client_pin.rs
@@ -679,7 +679,7 @@ impl AsRef<[u8]> for EncryptedPinToken {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Pin(String);
 
 impl fmt::Debug for Pin {

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -62,17 +62,17 @@ fn true_val() -> bool {
     true
 }
 
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-pub(crate) struct AuthenticatorOptions {
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq, Serialize)]
+pub struct AuthenticatorOptions {
     /// Indicates that the device is attached to the client and therefore can’t
     /// be removed and used on another client.
     #[serde(rename = "plat", default)]
-    pub(crate) platform_device: bool,
+    pub platform_device: bool,
     /// Indicates that the device is capable of storing keys on the device
     /// itself and therefore can satisfy the authenticatorGetAssertion request
     /// with allowList parameter not specified or empty.
     #[serde(rename = "rk", default)]
-    pub(crate) resident_key: bool,
+    pub resident_key: bool,
 
     /// Client PIN:
     ///  If present and set to true, it indicates that the device is capable of
@@ -83,11 +83,11 @@ pub(crate) struct AuthenticatorOptions {
     ///   PIN from the client.
     /// Client PIN is one of the ways to do user verification.
     #[serde(rename = "clientPin")]
-    pub(crate) client_pin: Option<bool>,
+    pub client_pin: Option<bool>,
 
     /// Indicates that the device is capable of testing user presence.
     #[serde(rename = "up", default = "true_val")]
-    pub(crate) user_presence: bool,
+    pub user_presence: bool,
 
     /// Indicates that the device is capable of verifying the user within
     /// itself. For example, devices with UI, biometrics fall into this
@@ -107,7 +107,7 @@ pub(crate) struct AuthenticatorOptions {
     // TODO(MS): My Token (key-ID FIDO2) does return Some(false) here, even though
     //           it has no built-in verification method. Not to be trusted...
     #[serde(rename = "uv")]
-    pub(crate) user_verification: Option<bool>,
+    pub user_verification: Option<bool>,
 
     // ----------------------------------------------------
     // CTAP 2.1 options
@@ -124,7 +124,7 @@ pub(crate) struct AuthenticatorOptions {
     ///  getPinUvAuthTokenUsingPinWithPermissions and getPinUvAuthTokenUsingUvWithPermissions
     ///  subcommands.
     #[serde(rename = "pinUvAuthToken")]
-    pub(crate) pin_uv_auth_token: Option<bool>,
+    pub pin_uv_auth_token: Option<bool>,
 
     /// If this noMcGaPermissionsWithClientPin is:
     /// present and set to true
@@ -141,7 +141,7 @@ pub(crate) struct AuthenticatorOptions {
     /// Note: noMcGaPermissionsWithClientPin MUST only be present if the
     ///       clientPin option ID is present.
     #[serde(rename = "noMcGaPermissionsWithClientPin")]
-    pub(crate) no_mc_ga_permissions_with_client_pin: Option<bool>,
+    pub no_mc_ga_permissions_with_client_pin: Option<bool>,
 
     /// If largeBlobs is:
     /// present and set to true
@@ -149,7 +149,7 @@ pub(crate) struct AuthenticatorOptions {
     /// present and set to false, or absent.
     ///  The authenticatorLargeBlobs command is NOT supported.
     #[serde(rename = "largeBlobs")]
-    pub(crate) large_blobs: Option<bool>,
+    pub large_blobs: Option<bool>,
 
     /// Enterprise Attestation feature support:
     /// If ep is:
@@ -162,7 +162,7 @@ pub(crate) struct AuthenticatorOptions {
     /// Absent
     ///  The Enterprise Attestation feature is NOT supported.
     #[serde(rename = "ep")]
-    pub(crate) ep: Option<bool>,
+    pub ep: Option<bool>,
 
     /// If bioEnroll is:
     /// present and set to true
@@ -174,7 +174,7 @@ pub(crate) struct AuthenticatorOptions {
     /// absent
     ///  the authenticatorBioEnrollment commands are NOT supported.
     #[serde(rename = "bioEnroll")]
-    pub(crate) bio_enroll: Option<bool>,
+    pub bio_enroll: Option<bool>,
 
     /// "FIDO_2_1_PRE" Prototype Credential management support:
     /// If userVerificationMgmtPreview is:
@@ -187,7 +187,7 @@ pub(crate) struct AuthenticatorOptions {
     /// absent
     ///  the Prototype authenticatorBioEnrollment (0x41) commands are not supported.
     #[serde(rename = "userVerificationMgmtPreview")]
-    pub(crate) user_verification_mgmt_preview: Option<bool>,
+    pub user_verification_mgmt_preview: Option<bool>,
 
     /// getPinUvAuthTokenUsingUvWithPermissions support for requesting the be permission:
     /// This option ID MUST only be present if bioEnroll is also present.
@@ -199,7 +199,7 @@ pub(crate) struct AuthenticatorOptions {
     ///  requesting the be permission when invoking getPinUvAuthTokenUsingUvWithPermissions
     ///  is NOT supported.
     #[serde(rename = "uvBioEnroll")]
-    pub(crate) uv_bio_enroll: Option<bool>,
+    pub uv_bio_enroll: Option<bool>,
 
     /// authenticatorConfig command support:
     /// If authnrCfg is:
@@ -208,7 +208,7 @@ pub(crate) struct AuthenticatorOptions {
     /// present and set to false, or absent.
     ///  the authenticatorConfig command is NOT supported.
     #[serde(rename = "authnrCfg")]
-    pub(crate) authnr_cfg: Option<bool>,
+    pub authnr_cfg: Option<bool>,
 
     /// getPinUvAuthTokenUsingUvWithPermissions support for requesting the acfg permission:
     /// This option ID MUST only be present if authnrCfg is also present.
@@ -220,7 +220,7 @@ pub(crate) struct AuthenticatorOptions {
     ///  requesting the acfg permission when invoking getPinUvAuthTokenUsingUvWithPermissions
     ///  is NOT supported.
     #[serde(rename = "uvAcfg")]
-    pub(crate) uv_acfg: Option<bool>,
+    pub uv_acfg: Option<bool>,
 
     /// Credential management support:
     /// If credMgmt is:
@@ -229,7 +229,7 @@ pub(crate) struct AuthenticatorOptions {
     /// present and set to false, or absent.
     ///  the authenticatorCredentialManagement command is NOT supported.
     #[serde(rename = "credMgmt")]
-    pub(crate) cred_mgmt: Option<bool>,
+    pub cred_mgmt: Option<bool>,
 
     /// "FIDO_2_1_PRE" Prototype Credential management support:
     /// If credentialMgmtPreview is:
@@ -238,7 +238,7 @@ pub(crate) struct AuthenticatorOptions {
     /// present and set to false, or absent.
     ///  the Prototype authenticatorCredentialManagement (0x41) command is NOT supported.
     #[serde(rename = "credentialMgmtPreview")]
-    pub(crate) credential_mgmt_preview: Option<bool>,
+    pub credential_mgmt_preview: Option<bool>,
 
     /// Support for the Set Minimum PIN Length feature.
     /// If setMinPINLength is:
@@ -248,7 +248,7 @@ pub(crate) struct AuthenticatorOptions {
     ///  the setMinPINLength subcommand is NOT supported.
     /// Note: setMinPINLength MUST only be present if the clientPin option ID is present.
     #[serde(rename = "setMinPINLength")]
-    pub(crate) set_min_pin_length: Option<bool>,
+    pub set_min_pin_length: Option<bool>,
 
     /// Support for making non-discoverable credentials without requiring User Verification.
     /// If makeCredUvNotRqd is:
@@ -261,7 +261,7 @@ pub(crate) struct AuthenticatorOptions {
     ///  for the authenticatorMakeCredential command.
     /// Authenticators SHOULD include this option with the value true.
     #[serde(rename = "makeCredUvNotRqd")]
-    pub(crate) make_cred_uv_not_rqd: Option<bool>,
+    pub make_cred_uv_not_rqd: Option<bool>,
 
     /// Support for the Always Require User Verification feature:
     /// If alwaysUv is
@@ -274,7 +274,7 @@ pub(crate) struct AuthenticatorOptions {
     /// Note: If the alwaysUv option ID is present and true the authenticator MUST set the value
     ///       of makeCredUvNotRqd to false.
     #[serde(rename = "alwaysUv")]
-    pub(crate) always_uv: Option<bool>,
+    pub always_uv: Option<bool>,
 }
 
 impl Default for AuthenticatorOptions {
@@ -312,30 +312,30 @@ pub enum AuthenticatorVersion {
     FIDO_2_1,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct AuthenticatorInfo {
-    pub(crate) versions: Vec<AuthenticatorVersion>,
-    pub(crate) extensions: Vec<String>,
-    pub(crate) aaguid: AAGuid,
-    pub(crate) options: AuthenticatorOptions,
-    pub(crate) max_msg_size: Option<usize>,
-    pub(crate) pin_protocols: Vec<u64>,
+    pub versions: Vec<AuthenticatorVersion>,
+    pub extensions: Vec<String>,
+    pub aaguid: AAGuid,
+    pub options: AuthenticatorOptions,
+    pub max_msg_size: Option<usize>,
+    pub pin_protocols: Vec<u64>,
     // CTAP 2.1
-    pub(crate) max_credential_count_in_list: Option<usize>,
-    pub(crate) max_credential_id_length: Option<usize>,
-    pub(crate) transports: Option<Vec<String>>,
-    pub(crate) algorithms: Option<Vec<PublicKeyCredentialParameters>>,
-    pub(crate) max_ser_large_blob_array: Option<u64>,
-    pub(crate) force_pin_change: Option<bool>,
-    pub(crate) min_pin_length: Option<u64>,
-    pub(crate) firmware_version: Option<u64>,
-    pub(crate) max_cred_blob_length: Option<u64>,
-    pub(crate) max_rpids_for_set_min_pin_length: Option<u64>,
-    pub(crate) preferred_platform_uv_attempts: Option<u64>,
-    pub(crate) uv_modality: Option<u64>,
-    pub(crate) certifications: Option<BTreeMap<String, u64>>,
-    pub(crate) remaining_discoverable_credentials: Option<u64>,
-    pub(crate) vendor_prototype_config_commands: Option<Vec<u64>>,
+    pub max_credential_count_in_list: Option<usize>,
+    pub max_credential_id_length: Option<usize>,
+    pub transports: Option<Vec<String>>,
+    pub algorithms: Option<Vec<PublicKeyCredentialParameters>>,
+    pub max_ser_large_blob_array: Option<u64>,
+    pub force_pin_change: Option<bool>,
+    pub min_pin_length: Option<u64>,
+    pub firmware_version: Option<u64>,
+    pub max_cred_blob_length: Option<u64>,
+    pub max_rpids_for_set_min_pin_length: Option<u64>,
+    pub preferred_platform_uv_attempts: Option<u64>,
+    pub uv_modality: Option<u64>,
+    pub certifications: Option<BTreeMap<String, u64>>,
+    pub remaining_discoverable_credentials: Option<u64>,
+    pub vendor_prototype_config_commands: Option<Vec<u64>>,
 }
 
 impl AuthenticatorInfo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub use ctap2::attestation::AttestationObject;
 pub use ctap2::client_data::CollectedClientData;
 pub use ctap2::commands::client_pin::{Pin, PinError};
 pub use ctap2::commands::get_assertion::Assertion;
+pub use ctap2::commands::get_info::AuthenticatorInfo;
 pub use ctap2::AssertionObject;
 
 pub mod errors;

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -33,10 +33,10 @@ use crate::transport::{errors::HIDError, hid::HIDDevice, FidoDevice, Nonce};
 use crate::u2fprotocol::{u2f_init_device, u2f_is_keyhandle_valid, u2f_register, u2f_sign};
 use crate::u2ftypes::U2FDevice;
 use crate::{
-    send_status, AuthenticatorTransports, KeyHandle, RegisterFlags, RegisterResult, SignFlags,
-    SignResult, StatusPinUv, StatusUpdate,
+    send_status, AuthenticatorTransports, InteractiveRequest, KeyHandle, RegisterFlags,
+    RegisterResult, SignFlags, SignResult, StatusPinUv, StatusUpdate,
 };
-use std::sync::mpsc::{channel, Sender};
+use std::sync::mpsc::{channel, RecvError, RecvTimeoutError, Sender};
 use std::thread;
 use std::time::Duration;
 
@@ -185,9 +185,9 @@ impl StateMachine {
         }
         match rx.recv() {
             Ok(pin) => Ok(pin),
-            Err(_) => {
+            Err(RecvError) => {
                 // recv() can only fail, if the other side is dropping the Sender.
-                error!("Callback dropped the channel. Aborting.");
+                info!("Callback dropped the channel. Aborting.");
                 callback.call(Err(AuthenticatorError::CancelledByUser));
                 Err(())
             }
@@ -861,6 +861,45 @@ impl StateMachine {
         }
     }
 
+    pub fn reset_helper(
+        dev: &mut Device,
+        selector: Sender<DeviceSelectorEvent>,
+        status: Sender<crate::StatusUpdate>,
+        callback: StateCallback<crate::Result<crate::ResetResult>>,
+        keep_alive: &dyn Fn() -> bool,
+    ) {
+        let reset = Reset {};
+        info!("Device {:?} continues with the reset process", dev.id());
+        debug!("------------------------------------------------------------------");
+        debug!("{:?}", reset);
+        debug!("------------------------------------------------------------------");
+
+        let resp = dev.send_cbor_cancellable(&reset, keep_alive);
+        if resp.is_ok() {
+            send_status(
+                &status,
+                crate::StatusUpdate::Success {
+                    dev_info: dev.get_device_info(),
+                },
+            );
+            // The DeviceSelector could already be dead, but it might also wait
+            // for us to respond, in order to cancel all other tokens in case
+            // we skipped the "blinking"-action and went straight for the actual
+            // request.
+            let _ = selector.send(DeviceSelectorEvent::SelectedToken(dev.id()));
+        }
+
+        match resp {
+            Ok(()) => callback.call(Ok(())),
+            Err(HIDError::DeviceNotSupported) | Err(HIDError::UnsupportedCommand) => {}
+            Err(HIDError::Command(CommandError::StatusCode(StatusCode::ChannelBusy, _))) => {}
+            Err(e) => {
+                warn!("error happened: {}", e);
+                callback.call(Err(AuthenticatorError::HIDError(e)));
+            }
+        }
+    }
+
     pub fn reset(
         &mut self,
         timeout: u64,
@@ -876,50 +915,110 @@ impl StateMachine {
             callback.clone(),
             status,
             move |info, selector, status, alive| {
-                let reset = Reset {};
                 let mut dev = match Self::init_and_select(info, &selector, true, alive) {
                     None => {
                         return;
                     }
                     Some(dev) => dev,
                 };
-
-                info!("Device {:?} continues with the reset process", dev.id());
-                debug!("------------------------------------------------------------------");
-                debug!("{:?}", reset);
-                debug!("------------------------------------------------------------------");
-
-                let resp = dev.send_cbor_cancellable(&reset, alive);
-                if resp.is_ok() {
-                    send_status(
-                        &status,
-                        crate::StatusUpdate::Success {
-                            dev_info: dev.get_device_info(),
-                        },
-                    );
-                    // The DeviceSelector could already be dead, but it might also wait
-                    // for us to respond, in order to cancel all other tokens in case
-                    // we skipped the "blinking"-action and went straight for the actual
-                    // request.
-                    let _ = selector.send(DeviceSelectorEvent::SelectedToken(dev.id()));
-                }
-
-                match resp {
-                    Ok(()) => callback.call(Ok(())),
-                    Err(HIDError::DeviceNotSupported) | Err(HIDError::UnsupportedCommand) => {}
-                    Err(HIDError::Command(CommandError::StatusCode(
-                        StatusCode::ChannelBusy,
-                        _,
-                    ))) => {}
-                    Err(e) => {
-                        warn!("error happened: {}", e);
-                        callback.call(Err(AuthenticatorError::HIDError(e)));
-                    }
-                }
+                Self::reset_helper(&mut dev, selector, status, callback.clone(), alive);
             },
         );
 
         self.transaction = Some(try_or!(transaction, move |e| cbc.call(Err(e))));
+    }
+
+    pub fn set_or_change_pin_helper(
+        dev: &mut Device,
+        mut current_pin: Option<Pin>,
+        new_pin: Pin,
+        status: Sender<crate::StatusUpdate>,
+        callback: StateCallback<crate::Result<crate::ResetResult>>,
+        alive: &dyn Fn() -> bool,
+    ) {
+        let mut shared_secret = match dev.establish_shared_secret() {
+            Ok(s) => s,
+            Err(e) => {
+                callback.call(Err(AuthenticatorError::HIDError(e)));
+                return;
+            }
+        };
+
+        let authinfo = match dev.get_authenticator_info() {
+            Some(i) => i.clone(),
+            None => {
+                callback.call(Err(HIDError::DeviceNotInitialized.into()));
+                return;
+            }
+        };
+
+        // If the device has a min PIN use that, otherwise default to 4 according to Spec
+        if new_pin.as_bytes().len() < authinfo.min_pin_length.unwrap_or(4) as usize {
+            callback.call(Err(AuthenticatorError::PinError(PinError::PinIsTooShort)));
+            return;
+        }
+
+        // As per Spec: "Maximum PIN Length: UTF-8 representation MUST NOT exceed 63 bytes"
+        if new_pin.as_bytes().len() >= 64 {
+            callback.call(Err(AuthenticatorError::PinError(PinError::PinIsTooLong(
+                new_pin.as_bytes().len(),
+            ))));
+            return;
+        }
+
+        // Check if a client-pin is already set, or if a new one should be created
+        let res = if Some(true) == authinfo.options.client_pin {
+            let mut res;
+            let mut was_invalid = false;
+            let mut retries = None;
+            loop {
+                // current_pin will only be Some() in the interactive mode (running `manage()`)
+                // In case that PIN is wrong, we want to avoid an endless-loop here with re-trying
+                // that wrong PIN all the time. So we `take()` it, and only test it once.
+                // If that PIN is wrong, we fall back to the "ask_user_for_pin"-method.
+                let curr_pin = match current_pin.take() {
+                    None => {
+                        match Self::ask_user_for_pin(was_invalid, retries, &status, &callback) {
+                            Ok(pin) => pin,
+                            _ => {
+                                return;
+                            }
+                        }
+                    }
+                    Some(pin) => pin,
+                };
+
+                res = ChangeExistingPin::new(&authinfo, &shared_secret, &curr_pin, &new_pin)
+                    .map_err(HIDError::Command)
+                    .and_then(|msg| dev.send_cbor_cancellable(&msg, alive))
+                    .map_err(|e| repackage_pin_errors(dev, e));
+
+                if let Err(AuthenticatorError::PinError(PinError::InvalidPin(r))) = res {
+                    was_invalid = true;
+                    retries = r;
+                    // We need to re-establish the shared secret for the next round.
+                    match dev.establish_shared_secret() {
+                        Ok(s) => {
+                            shared_secret = s;
+                        }
+                        Err(e) => {
+                            callback.call(Err(AuthenticatorError::HIDError(e)));
+                            return;
+                        }
+                    };
+
+                    continue;
+                } else {
+                    break;
+                }
+            }
+            res
+        } else {
+            dev.send_cbor_cancellable(&SetNewPin::new(&shared_secret, &new_pin), alive)
+                .map_err(AuthenticatorError::HIDError)
+        };
+
+        callback.call(res);
     }
 
     pub fn set_pin(
@@ -946,88 +1045,14 @@ impl StateMachine {
                     Some(dev) => dev,
                 };
 
-                let mut shared_secret = match dev.establish_shared_secret() {
-                    Ok(s) => s,
-                    Err(e) => {
-                        callback.call(Err(AuthenticatorError::HIDError(e)));
-                        return;
-                    }
-                };
-
-                let authinfo = match dev.get_authenticator_info() {
-                    Some(i) => i.clone(),
-                    None => {
-                        callback.call(Err(HIDError::DeviceNotInitialized.into()));
-                        return;
-                    }
-                };
-
-                // With CTAP2.1 we will have an adjustable required length for PINs
-                if new_pin.as_bytes().len() < 4 {
-                    callback.call(Err(AuthenticatorError::PinError(PinError::PinIsTooShort)));
-                    return;
-                }
-
-                if new_pin.as_bytes().len() > 64 {
-                    callback.call(Err(AuthenticatorError::PinError(PinError::PinIsTooLong(
-                        new_pin.as_bytes().len(),
-                    ))));
-                    return;
-                }
-
-                // Check if a client-pin is already set, or if a new one should be created
-                let res = if authinfo.options.client_pin.unwrap_or_default() {
-                    let mut res;
-                    let mut was_invalid = false;
-                    let mut retries = None;
-                    loop {
-                        let current_pin = match Self::ask_user_for_pin(
-                            was_invalid,
-                            retries,
-                            &status,
-                            &callback,
-                        ) {
-                            Ok(pin) => pin,
-                            _ => {
-                                return;
-                            }
-                        };
-
-                        res = ChangeExistingPin::new(
-                            &authinfo,
-                            &shared_secret,
-                            &current_pin,
-                            &new_pin,
-                        )
-                        .map_err(HIDError::Command)
-                        .and_then(|msg| dev.send_cbor_cancellable(&msg, alive))
-                        .map_err(|e| repackage_pin_errors(&mut dev, e));
-
-                        if let Err(AuthenticatorError::PinError(PinError::InvalidPin(r))) = res {
-                            was_invalid = true;
-                            retries = r;
-                            // We need to re-establish the shared secret for the next round.
-                            match dev.establish_shared_secret() {
-                                Ok(s) => {
-                                    shared_secret = s;
-                                }
-                                Err(e) => {
-                                    callback.call(Err(AuthenticatorError::HIDError(e)));
-                                    return;
-                                }
-                            };
-
-                            continue;
-                        } else {
-                            break;
-                        }
-                    }
-                    res
-                } else {
-                    dev.send_cbor_cancellable(&SetNewPin::new(&shared_secret, &new_pin), alive)
-                        .map_err(AuthenticatorError::HIDError)
-                };
-                callback.call(res);
+                Self::set_or_change_pin_helper(
+                    &mut dev,
+                    None,
+                    new_pin.clone(),
+                    status,
+                    callback.clone(),
+                    alive,
+                );
             },
         );
         self.transaction = Some(try_or!(transaction, move |e| cbc.call(Err(e))));
@@ -1045,7 +1070,6 @@ impl StateMachine {
     ) {
         // Abort any prior register/sign calls.
         self.cancel();
-
         let cbc = callback.clone();
 
         let transaction = Transaction::new(
@@ -1272,5 +1296,96 @@ impl StateMachine {
         );
 
         self.transaction = Some(try_or!(transaction, |e| cbc.call(Err(e))));
+    }
+
+    // Function to interactively manage a specific token.
+    // Difference to register/sign: These want to do something and don't care
+    // with which token they do it.
+    // This function wants to manipulate a specific token. For this, we first
+    // have to select one and then do something with it, based on what it
+    // supports (Set PIN, Change PIN, Reset, etc.).
+    // Hence, we first go through the discovery-phase, then provide the user
+    // with the AuthenticatorInfo and then let them interactively decide what to do
+    pub fn manage(
+        &mut self,
+        timeout: u64,
+        status: Sender<crate::StatusUpdate>,
+        callback: StateCallback<crate::Result<crate::ResetResult>>,
+    ) {
+        // Abort any prior register/sign calls.
+        self.cancel();
+        let cbc = callback.clone();
+
+        let transaction = Transaction::new(
+            timeout,
+            callback.clone(),
+            status,
+            move |info, selector, status, alive| {
+                let mut dev = match Self::init_and_select(info, &selector, true, alive) {
+                    None => {
+                        return;
+                    }
+                    Some(dev) => dev,
+                };
+
+                info!("Device {:?} selected for interactive management.", dev.id());
+
+                // Sending the user the info about the token
+                let (tx, rx) = channel();
+                send_status(
+                    &status,
+                    crate::StatusUpdate::InteractiveManagement((
+                        tx,
+                        dev.get_device_info(),
+                        dev.get_authenticator_info().cloned(),
+                    )),
+                );
+                while alive() {
+                    match rx.recv_timeout(Duration::from_millis(400)) {
+                        Ok(InteractiveRequest::Reset) => {
+                            Self::reset_helper(&mut dev, selector, status, callback.clone(), alive);
+                        }
+                        Ok(InteractiveRequest::ChangePIN(curr_pin, new_pin)) => {
+                            Self::set_or_change_pin_helper(
+                                &mut dev,
+                                Some(curr_pin),
+                                new_pin,
+                                status,
+                                callback.clone(),
+                                alive,
+                            );
+                        }
+                        Ok(InteractiveRequest::SetPIN(pin)) => {
+                            Self::set_or_change_pin_helper(
+                                &mut dev,
+                                None,
+                                pin,
+                                status,
+                                callback.clone(),
+                                alive,
+                            );
+                        }
+                        Err(RecvTimeoutError::Timeout) => {
+                            if !alive() {
+                                // We got stopped at some point
+                                callback.call(Err(AuthenticatorError::CancelledByUser));
+                                break;
+                            }
+                            continue;
+                        }
+                        Err(RecvTimeoutError::Disconnected) => {
+                            // recv() failed, because the other side is dropping the Sender.
+                            info!(
+                                "Callback dropped the channel, so we abort the interactive session"
+                            );
+                            callback.call(Err(AuthenticatorError::CancelledByUser));
+                        }
+                    }
+                    break;
+                }
+            },
+        );
+
+        self.transaction = Some(try_or!(transaction, move |e| cbc.call(Err(e))));
     }
 }


### PR DESCRIPTION
1. Add interactive management-functionality
2. Make AuthenticatorInfo public and serializable for serializing it to JSON
3. Add example binary

This PR looks bigger than it is, as in statemachine.rs, I refactored a lot of the original content out into separate functions that can be used by for the traditional and the interactive usage.