### PR TITLE
Implement UV-workflow for CTAP 2.1

### DIFF
--- a/examples/ctap1.rs
+++ b/examples/ctap1.rs
@@ -116,10 +116,10 @@ fn main() {
             Ok(StatusUpdate::Success { dev_info }) => {
                 println!("STATUS: success using device: {dev_info}");
             }
-            Ok(StatusUpdate::PinError(..))
-            | Ok(StatusUpdate::SelectDeviceNotice)
-            | Ok(StatusUpdate::DeviceSelected(..))
-            | Ok(StatusUpdate::PinAuthInvalid) => {
+            Ok(StatusUpdate::DeviceSelected(dev_info)) => {
+                println!("STATUS: Continuing with device: {dev_info}");
+            }
+            Ok(StatusUpdate::PinUvError(..)) | Ok(StatusUpdate::SelectDeviceNotice) => {
                 panic!("STATUS: This can't happen for CTAP1!");
             }
             Err(RecvError) => {

--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -11,9 +11,8 @@ use authenticator::{
     ctap2::server::{
         PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty, Transport, User,
     },
-    errors::PinError,
     statecallback::StateCallback,
-    COSEAlgorithm, Pin, RegisterResult, SignResult, StatusUpdate,
+    COSEAlgorithm, Pin, RegisterResult, SignResult, StatusPinUv, StatusUpdate,
 };
 use getopts::Options;
 use sha2::{Digest, Sha256};
@@ -100,38 +99,45 @@ fn main() {
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
                 println!("STATUS: Continuing with device: {dev_info}");
             }
-            Ok(StatusUpdate::PinError(error, sender)) => match error {
-                PinError::PinRequired => {
-                    let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")
-                        .expect("Failed to read PIN");
-                    sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
-                    continue;
-                }
-                PinError::InvalidPin(attempts) => {
-                    println!(
-                        "Wrong PIN! {}",
-                        attempts.map_or("Try again.".to_string(), |a| format!(
-                            "You have {a} attempts left."
-                        ))
-                    );
-                    let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")
-                        .expect("Failed to read PIN");
-                    sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
-                    continue;
-                }
-                PinError::PinAuthBlocked => {
-                    panic!("Too many failed attempts in one row. Your device has been temporarily blocked. Please unplug it and plug in again.")
-                }
-                PinError::PinBlocked => {
-                    panic!("Too many failed attempts. Your device has been blocked. Reset it.")
-                }
-                e => {
-                    panic!("Unexpected error: {:?}", e)
-                }
-            },
-            Ok(StatusUpdate::PinAuthInvalid) => {
-                println!("Internal UV usage failed (e.g. using the wrong finger for your fingerprint sensor).");
+            Ok(StatusUpdate::PinUvError(StatusPinUv::PinRequired(sender))) => {
+                let raw_pin =
+                    rpassword::prompt_password_stderr("Enter PIN: ").expect("Failed to read PIN");
+                sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
                 continue;
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::InvalidPin(sender, attempts))) => {
+                println!(
+                    "Wrong PIN! {}",
+                    attempts.map_or("Try again.".to_string(), |a| format!(
+                        "You have {a} attempts left."
+                    ))
+                );
+                let raw_pin =
+                    rpassword::prompt_password_stderr("Enter PIN: ").expect("Failed to read PIN");
+                sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
+                continue;
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::PinAuthBlocked)) => {
+                panic!("Too many failed attempts in one row. Your device has been temporarily blocked. Please unplug it and plug in again.")
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::PinBlocked)) => {
+                panic!("Too many failed attempts. Your device has been blocked. Reset it.")
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::InvalidUv(attempts))) => {
+                println!(
+                    "Wrong UV! {}",
+                    attempts.map_or("Try again.".to_string(), |a| format!(
+                        "You have {a} attempts left."
+                    ))
+                );
+                continue;
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::UvBlocked)) => {
+                println!("Too many failed UV-attempts.");
+                continue;
+            }
+            Ok(StatusUpdate::PinUvError(e)) => {
+                panic!("Unexpected error: {:?}", e)
             }
             Err(RecvError) => {
                 println!("STATUS: end");

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -116,10 +116,9 @@ fn main() {
             Ok(StatusUpdate::Success { dev_info }) => {
                 println!("STATUS: success using device: {dev_info}");
             }
-            Ok(StatusUpdate::PinError(..))
+            Ok(StatusUpdate::PinUvError(..))
             | Ok(StatusUpdate::SelectDeviceNotice)
-            | Ok(StatusUpdate::DeviceSelected(..))
-            | Ok(StatusUpdate::PinAuthInvalid) => {
+            | Ok(StatusUpdate::DeviceSelected(..)) => {
                 panic!("STATUS: This can't happen for CTAP1!");
             }
             Err(RecvError) => {

--- a/examples/reset.rs
+++ b/examples/reset.rs
@@ -109,7 +109,7 @@ fn main() {
                 println!("STATUS: Continuing with device: {dev_info}");
                 break;
             }
-            Ok(StatusUpdate::PinError(..)) => panic!("Reset should never ask for a PIN!"),
+            Ok(StatusUpdate::PinUvError(..)) => panic!("Reset should never ask for a PIN!"),
             Ok(_) => { /* Ignore all other updates */ }
             Err(RecvError) => {
                 println!("RecvError");

--- a/examples/set_pin.rs
+++ b/examples/set_pin.rs
@@ -5,7 +5,7 @@
 use authenticator::{
     authenticatorservice::{AuthenticatorService, CtapVersion},
     statecallback::StateCallback,
-    Pin, PinError, StatusUpdate,
+    Pin, StatusPinUv, StatusUpdate,
 };
 use getopts::Options;
 use std::sync::mpsc::{channel, RecvError};
@@ -85,38 +85,45 @@ fn main() {
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
                 println!("STATUS: Continuing with device: {dev_info}");
             }
-            Ok(StatusUpdate::PinError(error, sender)) => match error {
-                PinError::PinRequired => {
-                    let raw_pin = rpassword::prompt_password_stderr("Enter current PIN: ")
-                        .expect("Failed to read PIN");
-                    sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
-                    continue;
-                }
-                PinError::InvalidPin(attempts) => {
-                    println!(
-                        "Wrong PIN! {}",
-                        attempts.map_or("Try again.".to_string(), |a| format!(
-                            "You have {a} attempts left."
-                        ))
-                    );
-                    let raw_pin = rpassword::prompt_password_stderr("Enter current PIN: ")
-                        .expect("Failed to read PIN");
-                    sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
-                    continue;
-                }
-                PinError::PinAuthBlocked => {
-                    panic!("Too many failed attempts in one row. Your device has been temporarily blocked. Please unplug it and plug in again.")
-                }
-                PinError::PinBlocked => {
-                    panic!("Too many failed attempts. Your device has been blocked. Reset it.")
-                }
-                e => {
-                    panic!("Unexpected error: {:?}", e)
-                }
-            },
-            Ok(StatusUpdate::PinAuthInvalid) => {
-                println!("Internal UV usage failed (e.g. using the wrong finger for your fingerprint sensor).");
+            Ok(StatusUpdate::PinUvError(StatusPinUv::PinRequired(sender))) => {
+                let raw_pin =
+                    rpassword::prompt_password_stderr("Enter PIN: ").expect("Failed to read PIN");
+                sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
                 continue;
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::InvalidPin(sender, attempts))) => {
+                println!(
+                    "Wrong PIN! {}",
+                    attempts.map_or("Try again.".to_string(), |a| format!(
+                        "You have {a} attempts left."
+                    ))
+                );
+                let raw_pin =
+                    rpassword::prompt_password_stderr("Enter PIN: ").expect("Failed to read PIN");
+                sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
+                continue;
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::PinAuthBlocked)) => {
+                panic!("Too many failed attempts in one row. Your device has been temporarily blocked. Please unplug it and plug in again.")
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::PinBlocked)) => {
+                panic!("Too many failed attempts. Your device has been blocked. Reset it.")
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::InvalidUv(attempts))) => {
+                println!(
+                    "Wrong UV! {}",
+                    attempts.map_or("Try again.".to_string(), |a| format!(
+                        "You have {a} attempts left."
+                    ))
+                );
+                continue;
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::UvBlocked)) => {
+                println!("Too many failed UV-attempts.");
+                continue;
+            }
+            Ok(StatusUpdate::PinUvError(e)) => {
+                panic!("Unexpected error: {:?}", e)
             }
             Err(RecvError) => {
                 println!("STATUS: end");

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -10,9 +10,9 @@ use authenticator::{
     ctap2::server::{
         PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty, Transport, User,
     },
-    errors::{AuthenticatorError, CommandError, HIDError, PinError},
+    errors::{AuthenticatorError, CommandError, HIDError},
     statecallback::StateCallback,
-    COSEAlgorithm, Pin, RegisterResult, StatusUpdate,
+    COSEAlgorithm, Pin, RegisterResult, StatusPinUv, StatusUpdate,
 };
 
 use getopts::Options;
@@ -96,38 +96,45 @@ fn main() {
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
                 println!("STATUS: Continuing with device: {dev_info}");
             }
-            Ok(StatusUpdate::PinError(error, sender)) => match error {
-                PinError::PinRequired => {
-                    let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")
-                        .expect("Failed to read PIN");
-                    sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
-                    continue;
-                }
-                PinError::InvalidPin(attempts) => {
-                    println!(
-                        "Wrong PIN! {}",
-                        attempts.map_or("Try again.".to_string(), |a| format!(
-                            "You have {a} attempts left."
-                        ))
-                    );
-                    let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")
-                        .expect("Failed to read PIN");
-                    sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
-                    continue;
-                }
-                PinError::PinAuthBlocked => {
-                    panic!("Too many failed attempts in one row. Your device has been temporarily blocked. Please unplug it and plug in again.")
-                }
-                PinError::PinBlocked => {
-                    panic!("Too many failed attempts. Your device has been blocked. Reset it.")
-                }
-                e => {
-                    panic!("Unexpected error: {:?}", e)
-                }
-            },
-            Ok(StatusUpdate::PinAuthInvalid) => {
-                println!("Internal UV usage failed (e.g. using the wrong finger for your fingerprint sensor).");
+            Ok(StatusUpdate::PinUvError(StatusPinUv::PinRequired(sender))) => {
+                let raw_pin =
+                    rpassword::prompt_password_stderr("Enter PIN: ").expect("Failed to read PIN");
+                sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
                 continue;
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::InvalidPin(sender, attempts))) => {
+                println!(
+                    "Wrong PIN! {}",
+                    attempts.map_or("Try again.".to_string(), |a| format!(
+                        "You have {a} attempts left."
+                    ))
+                );
+                let raw_pin =
+                    rpassword::prompt_password_stderr("Enter PIN: ").expect("Failed to read PIN");
+                sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
+                continue;
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::PinAuthBlocked)) => {
+                panic!("Too many failed attempts in one row. Your device has been temporarily blocked. Please unplug it and plug in again.")
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::PinBlocked)) => {
+                panic!("Too many failed attempts. Your device has been blocked. Reset it.")
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::InvalidUv(attempts))) => {
+                println!(
+                    "Wrong UV! {}",
+                    attempts.map_or("Try again.".to_string(), |a| format!(
+                        "You have {a} attempts left."
+                    ))
+                );
+                continue;
+            }
+            Ok(StatusUpdate::PinUvError(StatusPinUv::UvBlocked)) => {
+                println!("Too many failed UV-attempts.");
+                continue;
+            }
+            Ok(StatusUpdate::PinUvError(e)) => {
+                panic!("Unexpected error: {:?}", e)
             }
             Err(RecvError) => {
                 println!("STATUS: end");

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::ctap2::commands::client_pin::PinUvAuthTokenPermission;
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::errors::AuthenticatorError;
 use crate::{ctap2::commands::CommandError, transport::errors::HIDError};
@@ -316,12 +317,14 @@ impl SharedSecret {
     }
     pub fn decrypt_pin_token(
         &self,
+        permissions: PinUvAuthTokenPermission,
         encrypted_pin_token: &[u8],
     ) -> Result<PinUvAuthToken, CryptoError> {
         let pin_token = self.decrypt(encrypted_pin_token)?;
         Ok(PinUvAuthToken {
             pin_protocol: self.pin_protocol.clone(),
             pin_token,
+            permissions,
         })
     }
     pub fn authenticate(&self, message: &[u8]) -> Result<Vec<u8>, CryptoError> {
@@ -339,7 +342,8 @@ impl SharedSecret {
 pub struct PinUvAuthToken {
     pub pin_protocol: PinUvAuthProtocol,
     pin_token: Vec<u8>,
-    // TODO(jms): add permissions
+    #[allow(dead_code)] // Not yet used
+    permissions: PinUvAuthTokenPermission,
 }
 
 impl PinUvAuthToken {

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -314,9 +314,12 @@ impl SharedSecret {
     pub fn decrypt(&self, ciphertext: &[u8]) -> Result<Vec<u8>, CryptoError> {
         self.pin_protocol.0.decrypt(&self.key, ciphertext)
     }
-    pub fn decrypt_pin_token(&self, encrypted_pin_token: &[u8]) -> Result<PinToken, CryptoError> {
+    pub fn decrypt_pin_token(
+        &self,
+        encrypted_pin_token: &[u8],
+    ) -> Result<PinUvAuthToken, CryptoError> {
         let pin_token = self.decrypt(encrypted_pin_token)?;
-        Ok(PinToken {
+        Ok(PinUvAuthToken {
             pin_protocol: self.pin_protocol.clone(),
             pin_token,
         })
@@ -333,13 +336,13 @@ impl SharedSecret {
 }
 
 #[derive(Clone)]
-pub struct PinToken {
+pub struct PinUvAuthToken {
     pub pin_protocol: PinUvAuthProtocol,
     pin_token: Vec<u8>,
     // TODO(jms): add permissions
 }
 
-impl PinToken {
+impl PinUvAuthToken {
     pub fn derive(&self, message: &[u8]) -> Result<PinUvAuthParam, CryptoError> {
         let pin_auth = self.pin_protocol.0.authenticate(&self.pin_token, message)?;
         Ok(PinUvAuthParam {

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -176,7 +176,7 @@ pub struct GetAssertion {
     pub(crate) extensions: GetAssertionExtensions,
     pub(crate) options: GetAssertionOptions,
     pub(crate) pin: Option<Pin>,
-    pub(crate) pin_auth: Option<PinUvAuthParam>,
+    pub(crate) pin_uv_auth_param: Option<PinUvAuthParam>,
 
     // This is used to implement the FIDO AppID extension.
     pub(crate) alternate_rp_id: Option<String>,
@@ -200,7 +200,7 @@ impl GetAssertion {
             extensions,
             options,
             pin,
-            pin_auth: None,
+            pin_uv_auth_param: None,
             alternate_rp_id,
         })
     }
@@ -215,8 +215,8 @@ impl PinUvAuthCommand for GetAssertion {
         self.pin = pin;
     }
 
-    fn set_pin_auth(&mut self, pin_auth: Option<PinUvAuthParam>) {
-        self.pin_auth = pin_auth;
+    fn set_pin_uv_auth_param(&mut self, pin_uv_auth_param: Option<PinUvAuthParam>) {
+        self.pin_uv_auth_param = pin_uv_auth_param;
     }
 
     fn client_data_hash(&self) -> ClientDataHash {
@@ -257,7 +257,7 @@ impl Serialize for GetAssertion {
         if self.options.has_some() {
             map_len += 1;
         }
-        if self.pin_auth.is_some() {
+        if self.pin_uv_auth_param.is_some() {
             map_len += 2;
         }
 
@@ -284,9 +284,9 @@ impl Serialize for GetAssertion {
         if self.options.has_some() {
             map.serialize_entry(&5, &self.options)?;
         }
-        if let Some(pin_auth) = &self.pin_auth {
-            map.serialize_entry(&6, &pin_auth)?;
-            map.serialize_entry(&7, &pin_auth.pin_protocol.id())?;
+        if let Some(pin_uv_auth_param) = &self.pin_uv_auth_param {
+            map.serialize_entry(&6, &pin_uv_auth_param)?;
+            map.serialize_entry(&7, &pin_uv_auth_param.pin_protocol.id())?;
         }
         map.end()
     }

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -223,8 +223,20 @@ impl PinUvAuthCommand for GetAssertion {
         self.client_data_wrapper.hash()
     }
 
-    fn unset_uv_option(&mut self) {
-        self.options.user_verification = None;
+    fn set_uv_option(&mut self, uv: Option<bool>) {
+        self.options.user_verification = uv;
+    }
+
+    fn get_uv_option(&mut self) -> Option<bool> {
+        self.options.user_verification
+    }
+
+    fn get_rp_id(&self) -> Option<&String> {
+        match &self.rp {
+            // CTAP1 case: We only have the hash, not the entire RpID
+            RelyingPartyWrapper::Hash(..) => None,
+            RelyingPartyWrapper::Data(r) => Some(&r.id),
+        }
     }
 }
 

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -110,7 +110,7 @@ pub struct MakeCredentials {
     pub(crate) extensions: MakeCredentialsExtensions,
     pub(crate) options: MakeCredentialsOptions,
     pub(crate) pin: Option<Pin>,
-    pub(crate) pin_auth: Option<PinUvAuthParam>,
+    pub(crate) pin_uv_auth_param: Option<PinUvAuthParam>,
     pub(crate) enterprise_attestation: Option<u64>,
 }
 
@@ -135,7 +135,7 @@ impl MakeCredentials {
             extensions,
             options,
             pin,
-            pin_auth: None,
+            pin_uv_auth_param: None,
             enterprise_attestation: None,
         })
     }
@@ -150,8 +150,8 @@ impl PinUvAuthCommand for MakeCredentials {
         self.pin = pin;
     }
 
-    fn set_pin_auth(&mut self, pin_auth: Option<PinUvAuthParam>) {
-        self.pin_auth = pin_auth;
+    fn set_pin_uv_auth_param(&mut self, pin_uv_auth_param: Option<PinUvAuthParam>) {
+        self.pin_uv_auth_param = pin_uv_auth_param;
     }
 
     fn client_data_hash(&self) -> ClientDataHash {
@@ -193,7 +193,7 @@ impl Serialize for MakeCredentials {
         if self.options.has_some() {
             map_len += 1;
         }
-        if self.pin_auth.is_some() {
+        if self.pin_uv_auth_param.is_some() {
             map_len += 2;
         }
         if self.enterprise_attestation.is_some() {
@@ -224,9 +224,9 @@ impl Serialize for MakeCredentials {
         if self.options.has_some() {
             map.serialize_entry(&0x07, &self.options)?;
         }
-        if let Some(pin_auth) = &self.pin_auth {
-            map.serialize_entry(&0x08, &pin_auth)?;
-            map.serialize_entry(&0x09, &pin_auth.pin_protocol.id())?;
+        if let Some(pin_uv_auth_param) = &self.pin_uv_auth_param {
+            map.serialize_entry(&0x08, &pin_uv_auth_param)?;
+            map.serialize_entry(&0x09, &pin_uv_auth_param.pin_protocol.id())?;
         }
         if let Some(enterprise_attestation) = self.enterprise_attestation {
             map.serialize_entry(&0x0a, &enterprise_attestation)?;

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -158,8 +158,20 @@ impl PinUvAuthCommand for MakeCredentials {
         self.client_data_wrapper.hash()
     }
 
-    fn unset_uv_option(&mut self) {
-        self.options.user_verification = None;
+    fn set_uv_option(&mut self, uv: Option<bool>) {
+        self.options.user_verification = uv;
+    }
+
+    fn get_uv_option(&mut self) -> Option<bool> {
+        self.options.user_verification
+    }
+
+    fn get_rp_id(&self) -> Option<&String> {
+        match &self.rp {
+            // CTAP1 case: We only have the hash, not the entire RpID
+            RelyingPartyWrapper::Hash(..) => None,
+            RelyingPartyWrapper::Data(r) => Some(&r.id),
+        }
     }
 }
 

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -1,8 +1,6 @@
-use crate::crypto::{CryptoError, PinUvAuthParam};
+use crate::crypto::{CryptoError, PinUvAuthToken};
 use crate::ctap2::client_data::ClientDataHash;
-use crate::ctap2::commands::client_pin::{
-    GetPinRetries, GetUvRetries, Pin, PinError, PinUvAuthTokenPermission,
-};
+use crate::ctap2::commands::client_pin::{GetPinRetries, GetUvRetries, Pin, PinError};
 use crate::errors::AuthenticatorError;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
 use crate::transport::FidoDevice;
@@ -114,120 +112,19 @@ pub(crate) enum PinUvAuthResult {
     SuccessGetPinUvAuthTokenUsingPinWithPermissions,
 }
 
+/// Helper-trait to determine pin_uv_auth_param from PIN or UV.
 pub(crate) trait PinUvAuthCommand: RequestCtap2 {
     fn pin(&self) -> &Option<Pin>;
     fn set_pin(&mut self, pin: Option<Pin>);
-    fn set_pin_uv_auth_param(&mut self, pin_uv_auth_param: Option<PinUvAuthParam>);
+    fn set_pin_uv_auth_param(
+        &mut self,
+        pin_uv_auth_token: Option<PinUvAuthToken>,
+    ) -> Result<(), AuthenticatorError>;
     fn client_data_hash(&self) -> ClientDataHash;
     fn set_uv_option(&mut self, uv: Option<bool>);
     fn get_uv_option(&mut self) -> Option<bool>;
     fn get_rp_id(&self) -> Option<&String>;
-
-    /// If Ok() is returned, the request can be sent to the device
-    /// If Err() is returned, either cancel the operation or ask the user for a PIN
-    fn determine_pin_uv_auth<D: FidoDevice>(
-        &mut self,
-        dev: &mut D,
-        skip_uv: bool,
-        permission: PinUvAuthTokenPermission,
-    ) -> Result<PinUvAuthResult, AuthenticatorError> {
-        // In case we error out in the middle
-        self.set_pin_uv_auth_param(None);
-
-        // CTAP1/U2F-only devices do not support PinUvAuth, so we skip it
-        if !dev.supports_ctap2() {
-            self.set_pin_uv_auth_param(None);
-            return Ok(PinUvAuthResult::DeviceIsCtap1);
-        }
-
-        // TODO: API needs a better way to express "uv = discouraged"
-        if self.get_uv_option() == Some(false) {
-            // MakeCredentials:
-            // "[..] the Relying Party wants to create a non-discoverable credential and not require user verification
-            // (e.g., by setting options.authenticatorSelection.userVerification to "discouraged" in the WebAuthn API),
-            // the platform invokes the authenticatorMakeCredential operation using the marshalled input parameters along
-            // with the "uv" option key set to false and terminate these steps."
-            // GetAssertion:
-            // "[..] the Relying Party does not wish to require user verification (e.g., by setting options.userVerification
-            // to "discouraged" in the WebAuthn API), the platform invokes the authenticatorGetAssertion operation using
-            // the marshalled input parameters along with an absent "uv" option key."
-            if Self::command() == Command::GetAssertion {
-                self.set_uv_option(None);
-            };
-            return Ok(PinUvAuthResult::NoAuthRequired);
-        }
-
-        let info = dev
-            .get_authenticator_info()
-            .ok_or(AuthenticatorError::HIDError(HIDError::DeviceNotInitialized))?;
-
-        // Only use UV, if the device supports it and we don't skip it
-        // which happens as a fallback, if UV-usage failed too many times
-        // Note: In theory, we could also repeatedly query GetInfo here and check
-        //       if uv is set to Some(true), as tokens should set it to Some(false)
-        //       if UV is blocked (too many failed attempts). But the CTAP2.0-spec is
-        //       vague and I don't trust all tokens to implement it that way. So we
-        //       keep track of it ourselves, using `skip_uv`.
-        let supports_uv = info.options.user_verification == Some(true);
-        let supports_pin = info.options.client_pin.is_some();
-        let pin_configured = info.options.client_pin == Some(true);
-
-        // Device does not support any auth-method
-        if !pin_configured && !supports_uv {
-            // We'll send it to the device anyways, and let it error out (or magically work)
-            return Ok(PinUvAuthResult::NoAuthTypeSupported);
-        }
-
-        let (res, pin_auth_token) = if info.options.pin_uv_auth_token == Some(true) {
-            if !skip_uv && supports_uv {
-                // CTAP 2.1 - UV
-                let pin_auth_token = dev
-                    .get_pin_uv_auth_token_using_uv_with_permissions(permission, self.get_rp_id());
-                (
-                    PinUvAuthResult::SuccessGetPinUvAuthTokenUsingUvWithPermissions,
-                    pin_auth_token,
-                )
-            } else if supports_pin && pin_configured {
-                // CTAP 2.1 - PIN
-                let pin_auth_token = dev.get_pin_uv_auth_token_using_pin_with_permissions(
-                    self.pin(),
-                    permission,
-                    self.get_rp_id(),
-                );
-                (
-                    PinUvAuthResult::SuccessGetPinUvAuthTokenUsingPinWithPermissions,
-                    pin_auth_token,
-                )
-            } else {
-                return Ok(PinUvAuthResult::NoAuthTypeSupported);
-            }
-        } else {
-            // CTAP 2.0 fallback
-            if !skip_uv && supports_uv && self.pin().is_none() {
-                // If the device supports internal user-verification (e.g. fingerprints),
-                // skip PIN-stuff
-
-                // We may need the shared secret for HMAC-extension, so we
-                // have to establish one
-                let _shared_secret = dev.establish_shared_secret()?;
-                return Ok(PinUvAuthResult::UsingInternalUv);
-            }
-
-            let pin_auth_token = dev.get_pin_token(self.pin());
-            (PinUvAuthResult::SuccessGetPinToken, pin_auth_token)
-        };
-
-        let pin_auth_param = pin_auth_token
-            .map_err(|e| repackage_pin_errors(dev, e))?
-            .derive(self.client_data_hash().as_ref())
-            .map_err(CommandError::Crypto)?;
-        self.set_pin_uv_auth_param(Some(pin_auth_param));
-        // CTAP 2.0 spec is a bit vague here, but CTAP 2.1 is very specific, that the request
-        // should either include pinAuth OR uv=true, but not both at the same time.
-        // Do not set user_verification, if pinAuth is provided
-        self.set_uv_option(None);
-        Ok(res)
-    }
+    fn set_discouraged_uv_option(&mut self);
 }
 
 pub(crate) fn repackage_pin_errors<D: FidoDevice>(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,6 +33,7 @@ pub enum AuthenticatorError {
     CryptoError,
     PinError(PinError),
     UnsupportedOption(UnsupportedOption),
+    CancelledByUser,
 }
 
 impl AuthenticatorError {
@@ -69,10 +70,9 @@ impl fmt::Display for AuthenticatorError {
                 write!(f, "A u2f token error occurred {err:?}")
             }
             AuthenticatorError::Custom(ref err) => write!(f, "A custom error occurred {err:?}"),
-            AuthenticatorError::VersionMismatch(manager, version) => write!(
-                f,
-                "{manager} expected arguments of version CTAP{version}"
-            ),
+            AuthenticatorError::VersionMismatch(manager, version) => {
+                write!(f, "{manager} expected arguments of version CTAP{version}")
+            }
             AuthenticatorError::HIDError(ref e) => write!(f, "Device error: {e}"),
             AuthenticatorError::CryptoError => {
                 write!(f, "The cryptography implementation encountered an error")
@@ -80,6 +80,9 @@ impl fmt::Display for AuthenticatorError {
             AuthenticatorError::PinError(ref e) => write!(f, "PIN Error: {e}"),
             AuthenticatorError::UnsupportedOption(ref e) => {
                 write!(f, "Unsupported option: {e:?}")
+            }
+            AuthenticatorError::CancelledByUser => {
+                write!(f, "Cancelled by user.")
             }
         }
     }

--- a/src/status_update.rs
+++ b/src/status_update.rs
@@ -118,7 +118,7 @@ pub mod tests {
         let json = to_string(&st).expect("Failed to serialize");
         assert_eq!(&json, r#"{"PinUvError":{"InvalidPin":3}}"#);
 
-        let st = StatusUpdate::PinUvError(StatusPinUv::InvalidPin(tx.clone(), None));
+        let st = StatusUpdate::PinUvError(StatusPinUv::InvalidPin(tx, None));
         let json = to_string(&st).expect("Failed to serialize");
         assert_eq!(&json, r#"{"PinUvError":{"InvalidPin":null}}"#);
 

--- a/src/status_update.rs
+++ b/src/status_update.rs
@@ -1,6 +1,52 @@
-use super::{u2ftypes, Pin, PinError};
-use serde::ser::{Serialize, SerializeStruct};
+use super::{u2ftypes, Pin};
+use serde::{
+    ser::{Serialize, SerializeStruct},
+    Serialize as DeriveSer, Serializer,
+};
 use std::sync::mpsc::Sender;
+
+// Simply ignoring the Sender when serializing
+pub(crate) fn serialize_pin_required<S>(_: &Sender<Pin>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_none()
+}
+
+// Simply ignoring the Sender when serializing
+pub(crate) fn serialize_pin_invalid<S>(
+    _: &Sender<Pin>,
+    retries: &Option<u8>,
+    s: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(r) = retries {
+        s.serialize_u8(*r)
+    } else {
+        s.serialize_none()
+    }
+}
+
+#[derive(Debug, DeriveSer)]
+pub enum StatusPinUv {
+    #[serde(serialize_with = "serialize_pin_required")]
+    PinRequired(Sender<Pin>),
+    #[serde(serialize_with = "serialize_pin_invalid")]
+    InvalidPin(Sender<Pin>, Option<u8>),
+    PinIsTooShort,
+    PinIsTooLong(usize),
+    InvalidUv(Option<u8>),
+    // This SHOULD ever only happen for CTAP2.0 devices that
+    // use internal UV (e.g. fingerprint sensors) and failed (e.g. wrong
+    // finger used).
+    // PinAuthInvalid, // Folded into InvalidUv
+    PinAuthBlocked,
+    PinBlocked,
+    PinNotSet,
+    UvBlocked,
+}
 
 #[derive(Debug)]
 pub enum StatusUpdate {
@@ -12,11 +58,7 @@ pub enum StatusUpdate {
     Success { dev_info: u2ftypes::U2FDeviceInfo },
     /// Sent if a PIN is needed (or was wrong), or some other kind of PIN-related
     /// error occurred. The Sender is for sending back a PIN (if needed).
-    PinError(PinError, Sender<Pin>),
-    /// This SHOULD ever only happen for CTAP2.0 devices that
-    /// use internal UV (e.g. fingerprint sensors) and failed (e.g. wrong
-    /// finger used).
-    PinAuthInvalid,
+    PinUvError(StatusPinUv),
     /// Sent, if multiple devices are found and the user has to select one
     SelectDeviceNotice,
     /// Sent, once a device was selected (either automatically or by user-interaction)
@@ -38,9 +80,8 @@ impl Serialize for StatusUpdate {
                 map.serialize_field("DeviceUnavailable", &dev_info)?
             }
             StatusUpdate::Success { dev_info } => map.serialize_field("Success", &dev_info)?,
-            StatusUpdate::PinError(e, _) => map.serialize_field("PinError", &e)?,
+            StatusUpdate::PinUvError(e) => map.serialize_field("PinUvError", &e)?,
             StatusUpdate::SelectDeviceNotice => map.serialize_field("SelectDeviceNotice", &())?,
-            StatusUpdate::PinAuthInvalid => map.serialize_field("PinAuthInvalid", &())?,
             StatusUpdate::DeviceSelected(dev_info) => {
                 map.serialize_field("DeviceSelected", &dev_info)?
             }
@@ -71,15 +112,19 @@ pub mod tests {
     }
 
     #[test]
-    fn serialize_invalid_pin() {
+    fn serialize_status_pin_uv() {
         let (tx, _rx) = channel();
-        let st = StatusUpdate::PinError(PinError::InvalidPin(Some(3)), tx.clone());
+        let st = StatusUpdate::PinUvError(StatusPinUv::InvalidPin(tx.clone(), Some(3)));
         let json = to_string(&st).expect("Failed to serialize");
-        assert_eq!(&json, r#"{"PinError":{"InvalidPin":3}}"#);
+        assert_eq!(&json, r#"{"PinUvError":{"InvalidPin":3}}"#);
 
-        let st = StatusUpdate::PinError(PinError::InvalidPin(None), tx);
+        let st = StatusUpdate::PinUvError(StatusPinUv::InvalidPin(tx.clone(), None));
         let json = to_string(&st).expect("Failed to serialize");
-        assert_eq!(&json, r#"{"PinError":{"InvalidPin":null}}"#);
+        assert_eq!(&json, r#"{"PinUvError":{"InvalidPin":null}}"#);
+
+        let st = StatusUpdate::PinUvError(StatusPinUv::PinBlocked);
+        let json = to_string(&st).expect("Failed to serialize");
+        assert_eq!(&json, r#"{"PinUvError":"PinBlocked"}"#);
     }
 
     #[test]

--- a/src/transport/freebsd/device.rs
+++ b/src/transport/freebsd/device.rs
@@ -5,9 +5,10 @@
 extern crate libc;
 
 use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
+use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::uhid;
-use crate::transport::{AuthenticatorInfo, FidoDevice, HIDError, SharedSecret};
+use crate::transport::{FidoDevice, HIDError, SharedSecret};
 use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
 use crate::util::from_unix_result;
 use crate::util::io_err;

--- a/src/transport/linux/device.rs
+++ b/src/transport/linux/device.rs
@@ -4,9 +4,10 @@
 
 extern crate libc;
 use crate::consts::CID_BROADCAST;
+use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::{hidraw, monitor};
-use crate::transport::{AuthenticatorInfo, FidoDevice, HIDError, SharedSecret};
+use crate::transport::{FidoDevice, HIDError, SharedSecret};
 use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
 use crate::util::from_unix_result;
 use std::fs::OpenOptions;

--- a/src/transport/macos/device.rs
+++ b/src/transport/macos/device.rs
@@ -5,9 +5,10 @@
 extern crate log;
 
 use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
+use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::iokit::*;
-use crate::transport::{AuthenticatorInfo, FidoDevice, HIDError, SharedSecret};
+use crate::transport::{FidoDevice, HIDError, SharedSecret};
 use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
 use core_foundation::base::*;
 use core_foundation::string::*;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,7 +1,10 @@
 use crate::consts::HIDCmd;
-use crate::crypto::SharedSecret;
-use crate::ctap2::commands::client_pin::GetKeyAgreement;
-use crate::ctap2::commands::get_info::{AuthenticatorInfo, AuthenticatorVersion, GetInfo};
+use crate::crypto::{PinUvAuthProtocol, PinUvAuthToken, SharedSecret};
+use crate::ctap2::commands::client_pin::{
+    GetKeyAgreement, GetPinToken, GetPinUvAuthTokenUsingPinWithPermissions,
+    GetPinUvAuthTokenUsingUvWithPermissions, PinUvAuthTokenPermission,
+};
+use crate::ctap2::commands::get_info::{AuthenticatorVersion, GetInfo};
 use crate::ctap2::commands::get_version::GetVersion;
 use crate::ctap2::commands::make_credentials::dummy_make_credentials_cmd;
 use crate::ctap2::commands::selection::Selection;
@@ -12,6 +15,8 @@ use crate::transport::device_selector::BlinkResult;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
 use crate::transport::hid::HIDDevice;
 use crate::util::io_err;
+use crate::Pin;
+use std::convert::TryFrom;
 use std::thread;
 use std::time::Duration;
 
@@ -245,29 +250,83 @@ pub trait FidoDevice: HIDDevice {
         }
     }
 
-    fn establish_shared_secret(&mut self) -> Result<(SharedSecret, AuthenticatorInfo), HIDError> {
+    fn establish_shared_secret(&mut self) -> Result<SharedSecret, HIDError> {
         if !self.supports_ctap2() {
             return Err(HIDError::UnsupportedCommand);
         }
 
-        let info = if let Some(authenticator_info) = self.get_authenticator_info().cloned() {
-            authenticator_info
-        } else {
-            // We should already have it, since it is queried upon `init()`, but just to be safe
-            let info_command = GetInfo::default();
-            let info = self.send_cbor(&info_command)?;
-            debug!("infos: {:?}", info);
-
-            self.set_authenticator_info(info.clone());
-            info
-        };
+        let info = self
+            .get_authenticator_info()
+            .ok_or(HIDError::DeviceNotInitialized)?;
+        let pin_protocol = PinUvAuthProtocol::try_from(info)?;
 
         // Not reusing the shared secret here, if it exists, since we might start again
         // with a different PIN (e.g. if the last one was wrong)
-        let pin_command = GetKeyAgreement::new(&info)?;
+        let pin_command = GetKeyAgreement::new(pin_protocol);
         let device_key_agreement = self.send_cbor(&pin_command)?;
         let shared_secret = device_key_agreement.shared_secret()?;
         self.set_shared_secret(shared_secret.clone());
-        Ok((shared_secret, info))
+        Ok(shared_secret)
+    }
+
+    /// CTAP 2.0-only version:
+    /// "Getting pinUvAuthToken using getPinToken (superseded)"
+    fn get_pin_token(&mut self, pin: &Option<Pin>) -> Result<PinUvAuthToken, HIDError> {
+        // Asking the user for PIN before establishing the shared secret
+        let pin = pin
+            .as_ref()
+            .ok_or(CommandError::StatusCode(StatusCode::PinRequired, None))?;
+
+        // Not reusing the shared secret here, if it exists, since we might start again
+        // with a different PIN (e.g. if the last one was wrong)
+        let shared_secret = self.establish_shared_secret()?;
+
+        let pin_command = GetPinToken::new(&shared_secret, pin);
+        let pin_token = self.send_cbor(&pin_command)?;
+
+        Ok(pin_token)
+    }
+
+    fn get_pin_uv_auth_token_using_uv_with_permissions(
+        &mut self,
+        permission: PinUvAuthTokenPermission,
+        rp_id: Option<&String>,
+    ) -> Result<PinUvAuthToken, HIDError> {
+        // Not reusing the shared secret here, if it exists, since we might start again
+        // with a different PIN (e.g. if the last one was wrong)
+        let shared_secret = self.establish_shared_secret()?;
+        let pin_command = GetPinUvAuthTokenUsingUvWithPermissions::new(
+            &shared_secret,
+            permission,
+            rp_id.cloned(),
+        );
+        let pin_auth_token = self.send_cbor(&pin_command)?;
+
+        Ok(pin_auth_token)
+    }
+
+    fn get_pin_uv_auth_token_using_pin_with_permissions(
+        &mut self,
+        pin: &Option<Pin>,
+        permission: PinUvAuthTokenPermission,
+        rp_id: Option<&String>,
+    ) -> Result<PinUvAuthToken, HIDError> {
+        // Asking the user for PIN before establishing the shared secret
+        let pin = pin
+            .as_ref()
+            .ok_or(CommandError::StatusCode(StatusCode::PinRequired, None))?;
+
+        // Not reusing the shared secret here, if it exists, since we might start again
+        // with a different PIN (e.g. if the last one was wrong)
+        let shared_secret = self.establish_shared_secret()?;
+        let pin_command = GetPinUvAuthTokenUsingPinWithPermissions::new(
+            &shared_secret,
+            pin,
+            permission,
+            rp_id.cloned(),
+        );
+        let pin_auth_token = self.send_cbor(&pin_command)?;
+
+        Ok(pin_auth_token)
     }
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -292,8 +292,7 @@ pub trait FidoDevice: HIDDevice {
         permission: PinUvAuthTokenPermission,
         rp_id: Option<&String>,
     ) -> Result<PinUvAuthToken, HIDError> {
-        // Not reusing the shared secret here, if it exists, since we might start again
-        // with a different PIN (e.g. if the last one was wrong)
+        // Explicitly not reusing the shared secret here
         let shared_secret = self.establish_shared_secret()?;
         let pin_command = GetPinUvAuthTokenUsingUvWithPermissions::new(
             &shared_secret,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,7 +1,6 @@
 use crate::consts::HIDCmd;
-use crate::crypto::{PinUvAuthParam, SharedSecret};
-use crate::ctap2::client_data::ClientDataHash;
-use crate::ctap2::commands::client_pin::{GetKeyAgreement, GetPinToken};
+use crate::crypto::SharedSecret;
+use crate::ctap2::commands::client_pin::GetKeyAgreement;
 use crate::ctap2::commands::get_info::{AuthenticatorInfo, AuthenticatorVersion, GetInfo};
 use crate::ctap2::commands::get_version::GetVersion;
 use crate::ctap2::commands::make_credentials::dummy_make_credentials_cmd;
@@ -13,7 +12,6 @@ use crate::transport::device_selector::BlinkResult;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
 use crate::transport::hid::HIDDevice;
 use crate::util::io_err;
-use crate::Pin;
 use std::thread;
 use std::time::Duration;
 
@@ -271,34 +269,5 @@ pub trait FidoDevice: HIDDevice {
         let shared_secret = device_key_agreement.shared_secret()?;
         self.set_shared_secret(shared_secret.clone());
         Ok((shared_secret, info))
-    }
-
-    fn get_pin_token(
-        &mut self,
-        client_data_hash: &ClientDataHash,
-        pin: &Option<Pin>,
-    ) -> Result<Option<PinUvAuthParam>, HIDError> {
-        // Not reusing the shared secret here, if it exists, since we might start again
-        // with a different PIN (e.g. if the last one was wrong)
-        let (shared_secret, info) = self.establish_shared_secret()?;
-
-        // TODO(MS): What to do if token supports client_pin, but none has been set: Some(false)
-        //           AND a Pin is not None?
-        if info.options.client_pin == Some(true) {
-            let pin = pin
-                .as_ref()
-                .ok_or(CommandError::StatusCode(StatusCode::PinRequired, None))?;
-
-            let pin_command = GetPinToken::new(&shared_secret, pin);
-            let pin_token = self.send_cbor(&pin_command)?;
-
-            Ok(Some(
-                pin_token
-                    .derive(client_data_hash.as_ref())
-                    .map_err(CommandError::Crypto)?,
-            ))
-        } else {
-            Ok(None)
-        }
     }
 }

--- a/src/transport/netbsd/device.rs
+++ b/src/transport/netbsd/device.rs
@@ -4,11 +4,12 @@
 
 extern crate libc;
 use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
+use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::fd::Fd;
 use crate::transport::platform::monitor::WrappedOpenDevice;
 use crate::transport::platform::uhid;
-use crate::transport::{AuthenticatorInfo, FidoDevice, HIDError, SharedSecret};
+use crate::transport::{FidoDevice, HIDError, SharedSecret};
 use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
 use crate::util::io_err;
 use std::ffi::OsString;

--- a/src/transport/openbsd/device.rs
+++ b/src/transport/openbsd/device.rs
@@ -4,9 +4,10 @@
 
 extern crate libc;
 use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
+use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::monitor::WrappedOpenDevice;
-use crate::transport::{AuthenticatorInfo, FidoDevice, HIDError, SharedSecret};
+use crate::transport::{FidoDevice, HIDError, SharedSecret};
 use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
 use crate::util::{from_unix_result, io_err};
 use std::ffi::{CString, OsString};

--- a/src/transport/stub/device.rs
+++ b/src/transport/stub/device.rs
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::FidoDevice;
-use crate::transport::{AuthenticatorInfo, HIDError, SharedSecret};
+use crate::transport::{HIDError, SharedSecret};
 use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
 use std::hash::Hash;
 use std::io;

--- a/src/transport/windows/device.rs
+++ b/src/transport/windows/device.rs
@@ -4,8 +4,9 @@
 
 use super::winapi::DeviceCapabilities;
 use crate::consts::{CID_BROADCAST, FIDO_USAGE_PAGE, FIDO_USAGE_U2FHID, MAX_HID_RPT_SIZE};
+use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
-use crate::transport::{AuthenticatorInfo, FidoDevice, HIDError, SharedSecret};
+use crate::transport::{FidoDevice, HIDError, SharedSecret};
 use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
 use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};


### PR DESCRIPTION
First draft of CTAP2.1 UV.

Significant conceptual changes:
* Instead of letting the consumer of this crate decide, which PIN-errors are recoverable and which are not, we do that now internally. And only send a `Sender<Pin>` for `PinRequired` and `InvalidPin`. All other PIN-errors get send "one-way" as a normal status update.
* For this, we need to repackage `PinError`s yet again into a different enum
* Handle `uv = "discouraged"` somewhat (although not pretty, and Firefox doesn't use it yet)
* `get_shared_secret()` doesn't need any input anymore and also does not return the AuthenticatorInfo. For this `get_authenticator_info()` is now always unpacked with the assumption that it exists and we return a `DeviceNotInitialized`-error otherwise.

This needs rebasing once #239 lands (and may influence how #239 will look like).