### PR TITLE
Export AuthenticatorService::add_transport

### DIFF
--- a/src/authenticatorservice.rs
+++ b/src/authenticatorservice.rs
@@ -182,7 +182,7 @@ impl AuthenticatorService {
         self.add_u2f_usb_hid_platform_transports();
     }
 
-    fn add_transport(&mut self, boxed_token: Box<dyn AuthenticatorTransport + Send>) {
+    pub fn add_transport(&mut self, boxed_token: Box<dyn AuthenticatorTransport + Send>) {
         self.transports.push(Arc::new(Mutex::new(boxed_token)))
     }
 


### PR DESCRIPTION
We're going to implement an `AuthenticatorTransport` for virtual tokens as part of [Bug 1676679](https://bugzilla.mozilla.org/show_bug.cgi?id=1676679), and this is going to live in mozilla-central. So we'll need to call `AuthenticatorService::add_transport` from `authrs_bridge`.