### PR TITLE
Always set P1=0x03 (enforce-user-presence-and-sign) in CTAP1 register

### DIFF
--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -311,11 +311,7 @@ impl RequestCtap1 for MakeCredentials {
             )));
         }
 
-        let flags = if self.options.ask_user_verification() {
-            U2F_REQUEST_USER_PRESENCE
-        } else {
-            0
-        };
+        let flags = U2F_REQUEST_USER_PRESENCE;
 
         let mut register_data = Vec::with_capacity(2 * PARAMETER_SIZE);
         if self.is_ctap2_request() {
@@ -976,7 +972,7 @@ pub mod test {
         // CBOR Header
         0x0, // CLA
         0x1, // INS U2F_Register
-        0x0, // P1 Flags
+        0x3, // P1 Flags
         0x0, // P2
         0x0, 0x0, 0x40, // Lc
         // NOTE: This has been taken from CTAP2.0 spec, but the clientDataHash has been replaced


### PR DESCRIPTION
The spec says that we should set P1=0x00, but apparently there are a number of misbehaving tokens that allow registration to complete immediately (without a button tap) when P1=0x00. Chrome, Safari, and Windows Hello work around these misbehaving tokens by setting P1=0x03. Chrome's implementation is [here](https://source.chromium.org/chromium/chromium/src/+/main:device/fido/u2f_command_constructor.cc;l=99;drc=f37b11fe3cfd8d5f8294ef27d5c6c723a4028d89;bpv=1;bpt=0).

Thanks to Martin Kreichgauer for informing us of this workaround.