### PR TITLE
Bump version to 0.4.0-alpha.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authenticator"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.12"
 authors = ["J.C. Jones <jc@mozilla.com>", "Tim Taubert <ttaubert@mozilla.com>", "Kyle Machulis <kyle@nonpolynomial.com>"]
 keywords = ["ctap2", "u2f", "fido", "webauthn"]
 categories = ["cryptography", "hardware-support", "os"]


### PR DESCRIPTION
Note that 0.4.0-alpha11 (b8228e1) was cut off a different branch so we could take a bug fix in Firefox 113.