### PR TITLE
Skip shared secret if pin and hmac-secret are not supported

### DIFF
--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -481,7 +481,9 @@ impl StateMachineCtap2 {
 
                 // We may need the shared secret for HMAC-extension, so we
                 // have to establish one
-                let _shared_secret = dev.establish_shared_secret()?;
+                if info.supports_hmac_secret() {
+                    let _shared_secret = dev.establish_shared_secret()?;
+                }
                 return Ok(PinUvAuthResult::UsingInternalUv);
             }
 


### PR DESCRIPTION
I noticed while testing the latest firefox-nightly release that the `UnsupportedPinProtocol` error cropped up again for my device. It seems that changes related to hmac-secret that were added to #237 after I tested reintroduced calls to the ClientPin command. This PR fixes that by only establishing a shared secret in the CTAP2.0 UV flow if the hmac-secret extension is supported. 