### PR TITLE
Fix device selection

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -362,6 +362,15 @@ pub struct PinUvAuthParam {
     pin_auth: Vec<u8>,
 }
 
+impl PinUvAuthParam {
+    pub(crate) fn create_empty() -> Self {
+        Self {
+            pin_protocol: PinUvAuthProtocol(Box::new(PinUvAuth1 {})),
+            pin_auth: vec![],
+        }
+    }
+}
+
 impl Serialize for PinUvAuthParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -146,7 +146,7 @@ impl AuthenticatorTransport for Manager {
             args.pin,
             args.use_ctap1_fallback,
             // pin_auth will be filled in Statemachine, once we have a device
-        )?;
+        );
 
         let action = QueueAction::Register {
             timeout,


### PR DESCRIPTION
This was broken here: https://github.com/mozilla/authenticator-rs/pull/205/files#diff-3a01100aa9ede87a8b9d3de054cf0251c4c6516c089045e21a804d8c118cc80fL217-L220

I'm re-adding the removed lines (and for easier handling, also remove the unneeded `Result<>`-return type for `MakeCredentials::new()`).

If that empty value for `pin_auth` is not set, the device will return an error (PinRequired) if it is protected by a PIN, instead of blink.