### PR TITLE
Avoid direct use of `MakeCredentialsOptions` and `GetAssertionOptions` in the public API

### DIFF
--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -3,12 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use authenticator::{
-    authenticatorservice::{
-        AuthenticatorService, GetAssertionOptions, MakeCredentialsOptions,
-        RegisterArgs, SignArgs,
-    },
+    authenticatorservice::{AuthenticatorService, RegisterArgs, SignArgs},
     ctap2::server::{
-        PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty, Transport, User,
+        PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
+        ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
     },
     statecallback::StateCallback,
     COSEAlgorithm, Pin, RegisterResult, SignResult, StatusPinUv, StatusUpdate,
@@ -139,10 +137,8 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
             id: vec![],
             transports: vec![Transport::USB, Transport::NFC],
         }],
-        options: MakeCredentialsOptions {
-            resident_key: Some(true),
-            user_verification: Some(true),
-        },
+        user_verification_req: UserVerificationRequirement::Required,
+        resident_key_req: ResidentKeyRequirement::Required,
         extensions: Default::default(),
         pin: None,
         use_ctap1_fallback: false,
@@ -201,8 +197,8 @@ fn main() {
         return;
     }
 
-    let mut manager = AuthenticatorService::new()
-        .expect("The auth service should initialize safely");
+    let mut manager =
+        AuthenticatorService::new().expect("The auth service should initialize safely");
 
     if !matches.opt_present("no-u2f-usb-hid") {
         manager.add_u2f_usb_hid_platform_transports();
@@ -311,7 +307,8 @@ fn main() {
         origin,
         relying_party_id: "example.com".to_string(),
         allow_list,
-        options: GetAssertionOptions::default(),
+        user_verification_req: UserVerificationRequirement::Required,
+        user_presence_req: true,
         extensions: Default::default(),
         pin: None,
         alternate_rp_id: None,

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -3,12 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use authenticator::{
-    authenticatorservice::{
-        AuthenticatorService, MakeCredentialsOptions, RegisterArgs,
-    },
+    authenticatorservice::{AuthenticatorService, RegisterArgs},
     ctap2::commands::StatusCode,
     ctap2::server::{
-        PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty, Transport, User,
+        PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
+        ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
     },
     errors::{AuthenticatorError, CommandError, HIDError},
     statecallback::StateCallback,
@@ -48,8 +47,8 @@ fn main() {
         return;
     }
 
-    let mut manager = AuthenticatorService::new()
-        .expect("The auth service should initialize safely");
+    let mut manager =
+        AuthenticatorService::new().expect("The auth service should initialize safely");
 
     manager.add_u2f_usb_hid_platform_transports();
 
@@ -74,9 +73,6 @@ fn main() {
     let mut challenge = Sha256::new();
     challenge.update(challenge_str.as_bytes());
     let chall_bytes = challenge.finalize().into();
-
-    // TODO(MS): Needs to be added to RegisterArgsCtap2
-    // let flags = RegisterFlags::empty();
 
     let (status_tx, status_rx) = channel::<StatusUpdate>();
     thread::spawn(move || loop {
@@ -168,10 +164,8 @@ fn main() {
             },
         ],
         exclude_list: vec![],
-        options: MakeCredentialsOptions {
-            resident_key: None,
-            user_verification: None,
-        },
+        user_verification_req: UserVerificationRequirement::Preferred,
+        resident_key_req: ResidentKeyRequirement::Discouraged,
         extensions: Default::default(),
         pin: None,
         use_ctap1_fallback: false,
@@ -183,12 +177,8 @@ fn main() {
             register_tx.send(rv).unwrap();
         }));
 
-        if let Err(e) = manager.register(
-            timeout_ms,
-            ctap_args.clone(),
-            status_tx.clone(),
-            callback,
-        ) {
+        if let Err(e) = manager.register(timeout_ms, ctap_args.clone(), status_tx.clone(), callback)
+        {
             panic!("Couldn't register: {:?}", e);
         };
 

--- a/src/authenticatorservice.rs
+++ b/src/authenticatorservice.rs
@@ -3,14 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::ctap2::commands::client_pin::Pin;
-pub use crate::ctap2::commands::get_assertion::{
-    GetAssertionExtensions, GetAssertionOptions, HmacSecretExtension,
-};
-pub use crate::ctap2::commands::make_credentials::{
-    MakeCredentialsExtensions, MakeCredentialsOptions,
-};
+pub use crate::ctap2::commands::get_assertion::{GetAssertionExtensions, HmacSecretExtension};
+pub use crate::ctap2::commands::make_credentials::MakeCredentialsExtensions;
 use crate::ctap2::server::{
-    PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty, User,
+    PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
+    ResidentKeyRequirement, User, UserVerificationRequirement,
 };
 use crate::errors::*;
 use crate::manager::Manager;
@@ -25,7 +22,8 @@ pub struct RegisterArgs {
     pub user: User,
     pub pub_cred_params: Vec<PublicKeyCredentialParameters>,
     pub exclude_list: Vec<PublicKeyCredentialDescriptor>,
-    pub options: MakeCredentialsOptions,
+    pub user_verification_req: UserVerificationRequirement,
+    pub resident_key_req: ResidentKeyRequirement,
     pub extensions: MakeCredentialsExtensions,
     pub pin: Option<Pin>,
     pub use_ctap1_fallback: bool,
@@ -37,7 +35,8 @@ pub struct SignArgs {
     pub origin: String,
     pub relying_party_id: String,
     pub allow_list: Vec<PublicKeyCredentialDescriptor>,
-    pub options: GetAssertionOptions,
+    pub user_verification_req: UserVerificationRequirement,
+    pub user_presence_req: bool,
     pub extensions: GetAssertionExtensions,
     pub pin: Option<Pin>,
     pub alternate_rp_id: Option<String>,
@@ -298,7 +297,9 @@ impl AuthenticatorService {
 mod tests {
     use super::{AuthenticatorService, AuthenticatorTransport, Pin, RegisterArgs, SignArgs};
     use crate::consts::{Capability, PARAMETER_SIZE};
-    use crate::ctap2::server::{RelyingParty, User};
+    use crate::ctap2::server::{
+        RelyingParty, ResidentKeyRequirement, User, UserVerificationRequirement,
+    };
     use crate::statecallback::StateCallback;
     use crate::{RegisterResult, SignResult, StatusUpdate};
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -432,7 +433,8 @@ mod tests {
                     },
                     pub_cred_params: vec![],
                     exclude_list: vec![],
-                    options: Default::default(),
+                    user_verification_req: UserVerificationRequirement::Preferred,
+                    resident_key_req: ResidentKeyRequirement::Preferred,
                     extensions: Default::default(),
                     pin: None,
                     use_ctap1_fallback: false,
@@ -453,7 +455,8 @@ mod tests {
                     origin: "example.com".to_string(),
                     relying_party_id: "example.com".to_string(),
                     allow_list: vec![],
-                    options: Default::default(),
+                    user_verification_req: UserVerificationRequirement::Preferred,
+                    user_presence_req: true,
                     extensions: Default::default(),
                     pin: None,
                     alternate_rp_id: None,
@@ -511,7 +514,8 @@ mod tests {
                     },
                     pub_cred_params: vec![],
                     exclude_list: vec![],
-                    options: Default::default(),
+                    user_verification_req: UserVerificationRequirement::Preferred,
+                    resident_key_req: ResidentKeyRequirement::Preferred,
                     extensions: Default::default(),
                     pin: None,
                     use_ctap1_fallback: false,
@@ -555,7 +559,8 @@ mod tests {
                     origin: "example.com".to_string(),
                     relying_party_id: "example.com".to_string(),
                     allow_list: vec![],
-                    options: Default::default(),
+                    user_verification_req: UserVerificationRequirement::Preferred,
+                    user_presence_req: true,
                     extensions: Default::default(),
                     pin: None,
                     alternate_rp_id: None,
@@ -609,7 +614,8 @@ mod tests {
                     },
                     pub_cred_params: vec![],
                     exclude_list: vec![],
-                    options: Default::default(),
+                    user_verification_req: UserVerificationRequirement::Preferred,
+                    resident_key_req: ResidentKeyRequirement::Preferred,
                     extensions: Default::default(),
                     pin: None,
                     use_ctap1_fallback: false,

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -294,20 +294,10 @@ impl PinUvAuthCommand for GetAssertion {
         let supports_uv = info.options.user_verification == Some(true);
         let pin_configured = info.options.client_pin == Some(true);
         let device_protected = supports_uv || pin_configured;
-        let uv_preferred_or_required = uv_req != UserVerificationRequirement::Discouraged;
+        let uv_discouraged = uv_req == UserVerificationRequirement::Discouraged;
         let always_uv = info.options.always_uv == Some(true);
 
-        if always_uv || (device_protected && uv_preferred_or_required) {
-            // If the token is protected AND the RP doesn't specifically discourage UV, we have to use it
-            self.set_uv_option(Some(true));
-            false
-        } else {
-            // "[..] the Relying Party does not wish to require user verification (e.g., by setting options.userVerification
-            // to "discouraged" in the WebAuthn API), the platform invokes the authenticatorGetAssertion operation using
-            // the marshalled input parameters along with an absent "uv" option key."
-            self.set_uv_option(None);
-            true
-        }
+        !always_uv && (!device_protected || uv_discouraged)
     }
 }
 

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -218,7 +218,6 @@ pub struct GetAssertion {
 
     // This is used to implement the FIDO AppID extension.
     pub(crate) alternate_rp_id: Option<String>,
-    pub(crate) use_ctap1_fallback: bool,
 }
 
 impl GetAssertion {
@@ -230,9 +229,8 @@ impl GetAssertion {
         extensions: GetAssertionExtensions,
         pin: Option<Pin>,
         alternate_rp_id: Option<String>,
-        use_ctap1_fallback: bool,
-    ) -> Result<Self, HIDError> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             client_data_hash,
             rp,
             allow_list,
@@ -241,8 +239,7 @@ impl GetAssertion {
             pin,
             pin_uv_auth_param: None,
             alternate_rp_id,
-            use_ctap1_fallback,
-        })
+        }
     }
 }
 
@@ -730,9 +727,7 @@ pub mod test {
             Default::default(),
             None,
             None,
-            false,
-        )
-        .expect("Failed to create GetAssertion");
+        );
         let mut device = Device::new("commands/get_assertion").unwrap();
         let mut cid = [0u8; 4];
         thread_rng().fill_bytes(&mut cid);
@@ -933,9 +928,7 @@ pub mod test {
             Default::default(),
             None,
             None,
-            false,
-        )
-        .expect("Failed to create GetAssertion");
+        );
         let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
                                                                          // channel id
         let mut cid = [0u8; 4];
@@ -1022,9 +1015,7 @@ pub mod test {
             Default::default(),
             None,
             None,
-            false,
-        )
-        .expect("Failed to create GetAssertion");
+        );
 
         let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
                                                                          // channel id

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -274,10 +274,6 @@ impl PinUvAuthCommand for GetAssertion {
         self.options.user_verification = uv;
     }
 
-    fn get_uv_option(&mut self) -> Option<bool> {
-        self.options.user_verification
-    }
-
     fn get_rp_id(&self) -> Option<&String> {
         match &self.rp {
             // CTAP1 case: We only have the hash, not the entire RpID

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -174,7 +174,6 @@ pub struct MakeCredentials {
     pub(crate) pin: Option<Pin>,
     pub(crate) pin_uv_auth_param: Option<PinUvAuthParam>,
     pub(crate) enterprise_attestation: Option<u64>,
-    pub(crate) use_ctap1_fallback: bool,
 }
 
 impl MakeCredentials {
@@ -188,7 +187,6 @@ impl MakeCredentials {
         options: MakeCredentialsOptions,
         extensions: MakeCredentialsExtensions,
         pin: Option<Pin>,
-        use_ctap1_fallback: bool,
     ) -> Self {
         Self {
             client_data_hash,
@@ -201,7 +199,6 @@ impl MakeCredentials {
             pin,
             pin_uv_auth_param: None,
             enterprise_attestation: None,
-            use_ctap1_fallback,
         }
     }
 }
@@ -477,8 +474,7 @@ pub(crate) fn dummy_make_credentials_cmd() -> Result<MakeCredentials, HIDError> 
             cross_origin: false,
             token_binding: None,
         }
-        .hash()
-        .expect("failed to serialize client data"),
+        .hash()?,
         RelyingPartyWrapper::Data(RelyingParty {
             id: String::from("make.me.blink"),
             ..Default::default()
@@ -495,7 +491,6 @@ pub(crate) fn dummy_make_credentials_cmd() -> Result<MakeCredentials, HIDError> 
         MakeCredentialsOptions::default(),
         MakeCredentialsExtensions::default(),
         None,
-        false,
     );
     // Using a zero-length pinAuth will trigger the device to blink.
     // For CTAP1, this gets ignored anyways and we do a 'normal' register
@@ -653,7 +648,6 @@ pub mod test {
             },
             Default::default(),
             None,
-            false,
         );
 
         let mut device = Device::new("commands/make_credentials").unwrap(); // not really used (all functions ignore it)
@@ -712,7 +706,6 @@ pub mod test {
             },
             Default::default(),
             None,
-            false,
         );
 
         let mut device = Device::new("commands/make_credentials").unwrap(); // not really used (all functions ignore it)

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -267,21 +267,7 @@ impl PinUvAuthCommand for MakeCredentials {
         // but that is only relevant, if RP also discourages UV.
         let can_make_cred_without_uv = make_cred_uv_not_required && uv_discouraged;
 
-        if always_uv || (device_protected && !can_make_cred_without_uv) {
-            // If the token is protected, we have to require UV anyways
-            self.set_uv_option(Some(true));
-            false
-        } else {
-            // "[..] the Relying Party wants to create a non-discoverable credential and not require user verification
-            // (e.g., by setting options.authenticatorSelection.userVerification to "discouraged" in the WebAuthn API),
-            // the platform invokes the authenticatorMakeCredential operation using the marshalled input parameters along
-            // with the "uv" option key set to false and terminate these steps."
-            // Note: This is basically a no-op right now, since we use `get_uv_option() == Some(false)`, to determine if
-            //       the RP is discouraging UV. But we may change that part of the API in the future, so better to be
-            //       explicit here.
-            self.set_uv_option(Some(false));
-            true
-        }
+        !always_uv && (!device_protected || can_make_cred_without_uv)
     }
 }
 

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -232,10 +232,6 @@ impl PinUvAuthCommand for MakeCredentials {
         self.options.user_verification = uv;
     }
 
-    fn get_uv_option(&mut self) -> Option<bool> {
-        self.options.user_verification
-    }
-
     fn get_rp_id(&self) -> Option<&String> {
         match &self.rp {
             // CTAP1 case: We only have the hash, not the entire RpID

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -122,7 +122,6 @@ pub(crate) trait PinUvAuthCommand: RequestCtap2 {
         pin_uv_auth_token: Option<PinUvAuthToken>,
     ) -> Result<(), AuthenticatorError>;
     fn set_uv_option(&mut self, uv: Option<bool>);
-    fn get_uv_option(&mut self) -> Option<bool>;
     fn get_rp_id(&self) -> Option<&String>;
     fn can_skip_user_verification(
         &mut self,

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -2,6 +2,7 @@ use crate::crypto::{CryptoError, PinUvAuthToken};
 
 use crate::ctap2::commands::client_pin::{GetPinRetries, GetUvRetries, Pin, PinError};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
+use crate::ctap2::server::UserVerificationRequirement;
 use crate::errors::AuthenticatorError;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
 use crate::transport::FidoDevice;
@@ -123,7 +124,11 @@ pub(crate) trait PinUvAuthCommand: RequestCtap2 {
     fn set_uv_option(&mut self, uv: Option<bool>);
     fn get_uv_option(&mut self) -> Option<bool>;
     fn get_rp_id(&self) -> Option<&String>;
-    fn can_skip_user_verification(&mut self, info: &AuthenticatorInfo) -> bool;
+    fn can_skip_user_verification(
+        &mut self,
+        info: &AuthenticatorInfo,
+        uv_req: UserVerificationRequirement,
+    ) -> bool;
 }
 
 pub(crate) fn repackage_pin_errors<D: FidoDevice>(

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -300,14 +300,14 @@ impl From<&KeyHandle> for PublicKeyCredentialDescriptor {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ResidentKeyRequirement {
     Discouraged,
     Preferred,
     Required,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum UserVerificationRequirement {
     Discouraged,
     Preferred,

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -300,6 +300,20 @@ impl From<&KeyHandle> for PublicKeyCredentialDescriptor {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ResidentKeyRequirement {
+    Discouraged,
+    Preferred,
+    Required,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum UserVerificationRequirement {
+    Discouraged,
+    Preferred,
+    Required,
+}
+
 #[cfg(test)]
 mod test {
     use super::{

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,7 @@ use std::sync::mpsc;
 
 #[derive(Debug)]
 pub enum UnsupportedOption {
-    AllowList,
+    EmptyAllowList,
     HmacSecret,
     MaxPinLength,
     PubCredParams,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,8 +13,12 @@ use std::sync::mpsc;
 
 #[derive(Debug)]
 pub enum UnsupportedOption {
-    MaxPinLength,
+    AllowList,
     HmacSecret,
+    MaxPinLength,
+    PubCredParams,
+    ResidentKey,
+    UserVerification,
 }
 
 #[derive(Debug)]

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -5,10 +5,6 @@
 use crate::authenticatorservice::AuthenticatorTransport;
 use crate::authenticatorservice::{RegisterArgs, SignArgs};
 
-use crate::ctap2::client_data::ClientDataHash;
-use crate::ctap2::commands::get_assertion::GetAssertion;
-use crate::ctap2::commands::make_credentials::MakeCredentials;
-use crate::ctap2::server::{RelyingParty, RelyingPartyWrapper};
 use crate::errors::*;
 use crate::statecallback::StateCallback;
 use crate::statemachine::StateMachine;
@@ -21,13 +17,13 @@ use std::time::Duration;
 enum QueueAction {
     Register {
         timeout: u64,
-        make_credentials: MakeCredentials,
+        register_args: RegisterArgs,
         status: Sender<crate::StatusUpdate>,
         callback: StateCallback<crate::Result<crate::RegisterResult>>,
     },
     Sign {
         timeout: u64,
-        get_assertion: GetAssertion,
+        sign_args: SignArgs,
         status: Sender<crate::StatusUpdate>,
         callback: StateCallback<crate::Result<crate::SignResult>>,
     },
@@ -62,22 +58,22 @@ impl Manager {
                 match rx.recv_timeout(Duration::from_millis(50)) {
                     Ok(QueueAction::Register {
                         timeout,
-                        make_credentials,
+                        register_args,
                         status,
                         callback,
                     }) => {
                         // This must not block, otherwise we can't cancel.
-                        sm.register(timeout, make_credentials, status, callback);
+                        sm.register(timeout, register_args, status, callback);
                     }
 
                     Ok(QueueAction::Sign {
                         timeout,
-                        get_assertion,
+                        sign_args,
                         status,
                         callback,
                     }) => {
                         // This must not block, otherwise we can't cancel.
-                        sm.sign(timeout, get_assertion, status, callback);
+                        sm.sign(timeout, sign_args, status, callback);
                     }
 
                     Ok(QueueAction::Cancel) => {
@@ -131,26 +127,13 @@ impl AuthenticatorTransport for Manager {
     fn register(
         &mut self,
         timeout: u64,
-        args: RegisterArgs,
+        register_args: RegisterArgs,
         status: Sender<crate::StatusUpdate>,
         callback: StateCallback<crate::Result<crate::RegisterResult>>,
     ) -> Result<(), AuthenticatorError> {
-        let make_credentials = MakeCredentials::new(
-            ClientDataHash(args.client_data_hash),
-            RelyingPartyWrapper::Data(args.relying_party),
-            Some(args.user),
-            args.pub_cred_params,
-            args.exclude_list,
-            args.options,
-            args.extensions,
-            args.pin,
-            args.use_ctap1_fallback,
-            // pin_auth will be filled in Statemachine, once we have a device
-        );
-
         let action = QueueAction::Register {
             timeout,
-            make_credentials,
+            register_args,
             status,
             callback,
         };
@@ -160,28 +143,13 @@ impl AuthenticatorTransport for Manager {
     fn sign(
         &mut self,
         timeout: u64,
-        args: SignArgs,
+        sign_args: SignArgs,
         status: Sender<crate::StatusUpdate>,
         callback: StateCallback<crate::Result<crate::SignResult>>,
     ) -> crate::Result<()> {
-        let get_assertion = GetAssertion::new(
-            ClientDataHash(args.client_data_hash),
-            RelyingPartyWrapper::Data(RelyingParty {
-                id: args.relying_party_id,
-                name: None,
-                icon: None,
-            }),
-            args.allow_list,
-            args.options,
-            args.extensions,
-            args.pin,
-            args.alternate_rp_id,
-            args.use_ctap1_fallback,
-        )?;
-
         let action = QueueAction::Sign {
             timeout,
-            get_assertion,
+            sign_args,
             status,
             callback,
         };

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -201,6 +201,7 @@ impl StateMachine {
         dev: &mut Device,
         permission: PinUvAuthTokenPermission,
         skip_uv: bool,
+        uv_req: UserVerificationRequirement,
     ) -> Result<PinUvAuthResult, AuthenticatorError> {
         let info = dev
             .get_authenticator_info()
@@ -219,7 +220,7 @@ impl StateMachine {
 
         // Check if the combination of device-protection and request-options
         // are allowing for 'discouraged', meaning no auth required.
-        if cmd.can_skip_user_verification(info) {
+        if cmd.can_skip_user_verification(info, uv_req) {
             return Ok(PinUvAuthResult::NoAuthRequired);
         }
 
@@ -292,6 +293,7 @@ impl StateMachine {
         dev: &mut Device,
         mut skip_uv: bool,
         permission: PinUvAuthTokenPermission,
+        uv_req: UserVerificationRequirement,
         status: &Sender<StatusUpdate>,
         callback: &StateCallback<crate::Result<U>>,
         alive: &dyn Fn() -> bool,
@@ -307,7 +309,7 @@ impl StateMachine {
         while alive() {
             debug!("-----------------------------------------------------------------");
             debug!("Getting pinUvAuthParam");
-            match Self::get_pin_uv_auth_param(cmd, dev, permission, skip_uv) {
+            match Self::get_pin_uv_auth_param(cmd, dev, permission, skip_uv, uv_req) {
                 Ok(r) => {
                     return Ok(r);
                 }
@@ -484,6 +486,7 @@ impl StateMachine {
                         &mut dev,
                         skip_uv,
                         PinUvAuthTokenPermission::MakeCredential,
+                        args.user_verification_req,
                         &status,
                         &callback,
                         alive,
@@ -680,6 +683,7 @@ impl StateMachine {
                         &mut dev,
                         skip_uv,
                         PinUvAuthTokenPermission::GetAssertion,
+                        args.user_verification_req,
                         &status,
                         &callback,
                         alive,

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -702,7 +702,7 @@ impl StateMachine {
                     }
                     if args.allow_list.is_empty() {
                         callback.call(Err(AuthenticatorError::UnsupportedOption(
-                            UnsupportedOption::AllowList,
+                            UnsupportedOption::EmptyAllowList,
                         )));
                         return;
                     }


### PR DESCRIPTION
We were previously using the `user_verification` field in `MakeCredentialsOptions` and `GetAssertionOptions` to
1) encode the WebAuthn user verification requirement in the public API, and
2) encode the uv option in CTAP commands.

This was prone to bugs, e.g. #255.

This PR removes the `MakeCredentialsOptions` and `GetAssertionOptions` structs from the public API.

The "Improve handling of" patch also implements some checks from step 2 of Sections [10.2](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#u2f-authenticatorMakeCredential-interoperability) and [10.3](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#u2f-authenticatorGetAssertion-interoperability) of CTAP 2.1 that we were missing.

Resolves #255 