### PR TITLE
Remove HIDDevice::clone_device_as_write_only

### DIFF
--- a/src/transport/freebsd/device.rs
+++ b/src/transport/freebsd/device.rs
@@ -212,25 +212,6 @@ impl HIDDevice for Device {
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
     }
-
-    /// This is used for cancellation of blocking read()-requests.
-    /// With this, we can clone the Device, pass it to another thread and call "cancel()" on that.
-    fn clone_device_as_write_only(&self) -> Result<Self, HIDError> {
-        // Try to open the device.
-        // This can't really error out as we already did this conversion
-        let cstr = CString::new(self.path.as_bytes()).map_err(|_| (HIDError::DeviceError))?;
-        let fd = unsafe { libc::open(cstr.as_ptr(), libc::O_WRONLY) };
-        let fd =
-            from_unix_result(fd).map_err(|e| (HIDError::IO(Some(self.path.clone().into()), e)))?;
-        Ok(Self {
-            path: self.path.clone(),
-            fd,
-            cid: self.cid,
-            dev_info: self.dev_info.clone(),
-            secret: self.secret.clone(),
-            authenticator_info: self.authenticator_info.clone(),
-        })
-    }
 }
 
 impl FidoDevice for Device {}

--- a/src/transport/freebsd/transaction.rs
+++ b/src/transport/freebsd/transaction.rs
@@ -35,13 +35,12 @@ impl Transaction {
             + 'static,
         T: 'static,
     {
-        let status_sender = status.clone();
-        let device_selector = DeviceSelector::run(status);
+        let device_selector = DeviceSelector::run();
         let selector_sender = device_selector.clone_sender();
         let thread = RunLoop::new_with_timeout(
             move |alive| {
                 // Create a new device monitor.
-                let mut monitor = Monitor::new(new_device_cb, selector_sender, status_sender);
+                let mut monitor = Monitor::new(new_device_cb, selector_sender, status);
 
                 // Start polling for new devices.
                 try_or!(monitor.run(alive), |_| callback

--- a/src/transport/hid.rs
+++ b/src/transport/hid.rs
@@ -30,7 +30,6 @@ where
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo);
     fn set_shared_secret(&mut self, secret: SharedSecret);
     fn get_shared_secret(&self) -> Option<&SharedSecret>;
-    fn clone_device_as_write_only(&self) -> Result<Self, HIDError>;
 
     fn supports_ctap1(&self) -> bool {
         // CAPABILITY_NMSG:

--- a/src/transport/linux/device.rs
+++ b/src/transport/linux/device.rs
@@ -158,26 +158,6 @@ impl HIDDevice for Device {
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
     }
-
-    /// This is used for cancellation of blocking read()-requests.
-    /// With this, we can clone the Device, pass it to another thread and call "cancel()" on that.
-    fn clone_device_as_write_only(&self) -> Result<Self, HIDError> {
-        let fd = OpenOptions::new()
-            .write(true)
-            .open(&self.path)
-            .map_err(|e| (HIDError::IO(Some(self.path.clone()), e)))?;
-
-        Ok(Self {
-            path: self.path.clone(),
-            fd,
-            in_rpt_size: self.in_rpt_size,
-            out_rpt_size: self.out_rpt_size,
-            cid: self.cid,
-            dev_info: self.dev_info.clone(),
-            secret: self.secret.clone(),
-            authenticator_info: self.authenticator_info.clone(),
-        })
-    }
 }
 
 impl FidoDevice for Device {}

--- a/src/transport/linux/transaction.rs
+++ b/src/transport/linux/transaction.rs
@@ -35,13 +35,12 @@ impl Transaction {
             + 'static,
         T: 'static,
     {
-        let status_sender = status.clone();
-        let device_selector = DeviceSelector::run(status);
+        let device_selector = DeviceSelector::run();
         let selector_sender = device_selector.clone_sender();
         let thread = RunLoop::new_with_timeout(
             move |alive| {
                 // Create a new device monitor.
-                let mut monitor = Monitor::new(new_device_cb, selector_sender, status_sender);
+                let mut monitor = Monitor::new(new_device_cb, selector_sender, status);
 
                 // Start polling for new devices.
                 try_or!(monitor.run(alive), |_| callback

--- a/src/transport/macos/device.rs
+++ b/src/transport/macos/device.rs
@@ -204,19 +204,6 @@ impl HIDDevice for Device {
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
     }
-
-    /// This is used for cancellation of blocking read()-requests.
-    /// With this, we can clone the Device, pass it to another thread and call "cancel()" on that.
-    fn clone_device_as_write_only(&self) -> Result<Self, HIDError> {
-        Ok(Self {
-            device_ref: self.device_ref,
-            cid: self.cid,
-            report_rx: None,
-            dev_info: self.dev_info.clone(),
-            secret: self.secret.clone(),
-            authenticator_info: self.authenticator_info.clone(),
-        })
-    }
 }
 
 impl FidoDevice for Device {}

--- a/src/transport/macos/transaction.rs
+++ b/src/transport/macos/transaction.rs
@@ -46,8 +46,7 @@ impl Transaction {
     {
         let (tx, rx) = channel();
         let timeout = (timeout as f64) / 1000.0;
-        let status_sender = status.clone();
-        let device_selector = DeviceSelector::run(status);
+        let device_selector = DeviceSelector::run();
         let selector_sender = device_selector.clone_sender();
         let builder = thread::Builder::new();
         let thread = builder
@@ -61,7 +60,7 @@ impl Transaction {
                 obs.add_to_current_runloop();
 
                 // Create a new HID device monitor and start polling.
-                let mut monitor = Monitor::new(new_device_cb, selector_sender, status_sender);
+                let mut monitor = Monitor::new(new_device_cb, selector_sender, status);
                 try_or!(monitor.start(), |_| callback
                     .call(Err(errors::AuthenticatorError::Platform)));
 

--- a/src/transport/mock/device.rs
+++ b/src/transport/mock/device.rs
@@ -173,19 +173,6 @@ impl HIDDevice for Device {
         self.id.clone()
     }
 
-    fn clone_device_as_write_only(&self) -> Result<Self, HIDError> {
-        Ok(Device {
-            id: self.id.clone(),
-            cid: self.cid,
-            reads: self.reads.clone(),
-            writes: self.writes.clone(),
-            dev_info: self.dev_info.clone(),
-            authenticator_info: self.authenticator_info.clone(),
-            sender: self.sender.clone(),
-            receiver: None,
-        })
-    }
-
     fn is_u2f(&mut self) -> bool {
         self.sender.is_some()
     }

--- a/src/transport/netbsd/device.rs
+++ b/src/transport/netbsd/device.rs
@@ -225,21 +225,6 @@ impl HIDDevice for Device {
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
     }
-
-    /// This is used for cancellation of blocking read()-requests.
-    /// With this, we can clone the Device, pass it to another thread and call "cancel()" on that.
-    fn clone_device_as_write_only(&self) -> Result<Self, HIDError> {
-        // Try to open the device.
-        let fd = Fd::open(&self.path, libc::O_WRONLY)?;
-        Ok(Self {
-            path: self.path.clone(),
-            fd,
-            cid: self.cid,
-            dev_info: self.dev_info.clone(),
-            secret: self.secret.clone(),
-            authenticator_info: self.authenticator_info.clone(),
-        })
-    }
 }
 
 impl FidoDevice for Device {}

--- a/src/transport/netbsd/transaction.rs
+++ b/src/transport/netbsd/transaction.rs
@@ -35,13 +35,12 @@ impl Transaction {
             + 'static,
         T: 'static,
     {
-        let status_sender = status.clone();
-        let device_selector = DeviceSelector::run(status);
+        let device_selector = DeviceSelector::run();
         let selector_sender = device_selector.clone_sender();
         let thread = RunLoop::new_with_timeout(
             move |alive| {
                 // Create a new device monitor.
-                let mut monitor = Monitor::new(new_device_cb, selector_sender, status_sender);
+                let mut monitor = Monitor::new(new_device_cb, selector_sender, status);
 
                 // Start polling for new devices.
                 try_or!(monitor.run(alive), |_| callback

--- a/src/transport/openbsd/device.rs
+++ b/src/transport/openbsd/device.rs
@@ -201,27 +201,6 @@ impl HIDDevice for Device {
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
     }
-
-    /// This is used for cancellation of blocking read()-requests.
-    /// With this, we can clone the Device, pass it to another thread and call "cancel()" on that.
-    fn clone_device_as_write_only(&self) -> Result<Self, HIDError> {
-        // Try to open the device.
-        // This can't really error out as we already did this conversion
-        let cstr = CString::new(self.path.as_bytes()).map_err(|_| (HIDError::DeviceError))?;
-        let fd = unsafe { libc::open(cstr.as_ptr(), libc::O_WRONLY) };
-        let fd =
-            from_unix_result(fd).map_err(|e| (HIDError::IO(Some(self.path.clone().into()), e)))?;
-        Ok(Self {
-            path: self.path.clone(),
-            fd,
-            in_rpt_size: self.in_rpt_size,
-            out_rpt_size: self.out_rpt_size,
-            cid: self.cid,
-            dev_info: self.dev_info.clone(),
-            secret: self.secret.clone(),
-            authenticator_info: self.authenticator_info.clone(),
-        })
-    }
 }
 
 impl FidoDevice for Device {}

--- a/src/transport/openbsd/transaction.rs
+++ b/src/transport/openbsd/transaction.rs
@@ -35,13 +35,12 @@ impl Transaction {
             + 'static,
         T: 'static,
     {
-        let status_sender = status.clone();
-        let device_selector = DeviceSelector::run(status);
+        let device_selector = DeviceSelector::run();
         let selector_sender = device_selector.clone_sender();
         let thread = RunLoop::new_with_timeout(
             move |alive| {
                 // Create a new device monitor.
-                let mut monitor = Monitor::new(new_device_cb, selector_sender, status_sender);
+                let mut monitor = Monitor::new(new_device_cb, selector_sender, status);
 
                 // Start polling for new devices.
                 try_or!(monitor.run(alive), |_| callback

--- a/src/transport/stub/device.rs
+++ b/src/transport/stub/device.rs
@@ -96,10 +96,6 @@ impl HIDDevice for Device {
     fn get_shared_secret(&self) -> Option<&SharedSecret> {
         unimplemented!()
     }
-
-    fn clone_device_as_write_only(&self) -> Result<Self, HIDError> {
-        unimplemented!()
-    }
 }
 
 impl FidoDevice for Device {}

--- a/src/transport/stub/transaction.rs
+++ b/src/transport/stub/transaction.rs
@@ -16,7 +16,7 @@ impl Transaction {
     pub fn new<F, T>(
         timeout: u64,
         callback: StateCallback<crate::Result<T>>,
-        status: Sender<crate::StatusUpdate>,
+        _status: Sender<crate::StatusUpdate>,
         new_device_cb: F,
     ) -> crate::Result<Self>
     where
@@ -31,7 +31,7 @@ impl Transaction {
         T: 'static,
     {
         // Just to silence "unused"-warnings
-        let mut device_selector = DeviceSelector::run(status);
+        let mut device_selector = DeviceSelector::run();
         let _ = DeviceSelectorEvent::DevicesAdded(vec![]);
         let _ = DeviceSelectorEvent::DeviceRemoved(PathBuf::new());
         let _ = device_selector.clone_sender();

--- a/src/transport/windows/device.rs
+++ b/src/transport/windows/device.rs
@@ -149,24 +149,6 @@ impl HIDDevice for Device {
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
     }
-
-    /// This is used for cancellation of blocking read()-requests.
-    /// With this, we can clone the Device, pass it to another thread and call "cancel()" on that.
-    fn clone_device_as_write_only(&self) -> Result<Self, HIDError> {
-        let file = OpenOptions::new()
-            .write(true)
-            .open(&self.path)
-            .map_err(|e| (HIDError::IO(Some(self.path.clone().into()), e)))?;
-
-        Ok(Self {
-            path: self.path.clone(),
-            file,
-            cid: self.cid,
-            dev_info: self.dev_info.clone(),
-            secret: self.secret.clone(),
-            authenticator_info: self.authenticator_info.clone(),
-        })
-    }
 }
 
 impl FidoDevice for Device {}

--- a/src/transport/windows/transaction.rs
+++ b/src/transport/windows/transaction.rs
@@ -35,13 +35,12 @@ impl Transaction {
             + 'static,
         T: 'static,
     {
-        let status_sender = status.clone();
-        let device_selector = DeviceSelector::run(status);
+        let device_selector = DeviceSelector::run();
         let selector_sender = device_selector.clone_sender();
         let thread = RunLoop::new_with_timeout(
             move |alive| {
                 // Create a new device monitor.
-                let mut monitor = Monitor::new(new_device_cb, selector_sender, status_sender);
+                let mut monitor = Monitor::new(new_device_cb, selector_sender, status);
 
                 // Start polling for new devices.
                 try_or!(monitor.run(alive), |_| callback


### PR DESCRIPTION
riastradh observed in #252 that `HIDDevice::clone_device_as_write_only` is not implemented correctly on several operating systems. Due to the changes in 7e9cad878bcd03c3f4943372e236520a8edcf158, there's actually no need to write to the `Device` produced by `HIDDevice::clone_device_as_write_only`. However, the device metadata is still used by `DeviceSelector` to send status updates.

This PR removes `HIDDevice::clone_device_as_write_only` and makes `StateMachine` responsible for sending status updates that contain device metadata.

Resolves #252 

