### PR TITLE
Expose `AuthenticatorError::CredentialExcluded` in public API

### DIFF
--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -4,12 +4,11 @@
 
 use authenticator::{
     authenticatorservice::{AuthenticatorService, RegisterArgs},
-    ctap2::commands::StatusCode,
     ctap2::server::{
         PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
         ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
     },
-    errors::{AuthenticatorError, CommandError, HIDError},
+    errors::AuthenticatorError,
     statecallback::StateCallback,
     COSEAlgorithm, Pin, RegisterResult, StatusPinUv, StatusUpdate,
 };
@@ -201,10 +200,7 @@ fn main() {
                 }];
                 continue;
             }
-            Err(AuthenticatorError::HIDError(HIDError::Command(CommandError::StatusCode(
-                StatusCode::CredentialExcluded,
-                None,
-            )))) => {
+            Err(AuthenticatorError::CredentialExcluded) => {
                 println!("Got an 'already registered' error. Quitting.");
                 break;
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,6 +38,7 @@ pub enum AuthenticatorError {
     PinError(PinError),
     UnsupportedOption(UnsupportedOption),
     CancelledByUser,
+    CredentialExcluded,
 }
 
 impl std::error::Error for AuthenticatorError {}
@@ -72,6 +73,9 @@ impl fmt::Display for AuthenticatorError {
             }
             AuthenticatorError::CancelledByUser => {
                 write!(f, "Cancelled by user.")
+            }
+            AuthenticatorError::CredentialExcluded => {
+                write!(f, "Credential excluded.")
             }
         }
     }

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -624,6 +624,13 @@ impl StateMachine {
                             skip_uv = true;
                             continue;
                         }
+                        Err(HIDError::Command(CommandError::StatusCode(
+                            StatusCode::CredentialExcluded,
+                            _,
+                        ))) => {
+                            callback.call(Err(AuthenticatorError::CredentialExcluded));
+                            break;
+                        }
                         Err(e) => {
                             warn!("error happened: {e}");
                             callback.call(Err(AuthenticatorError::HIDError(e)));


### PR DESCRIPTION
The CTAP2 `authenticatorMakeCredential` command takes an `excludeList` parameter that is used to prevent the user from storing multiple credentials for the same account on one authenticator. When a token finds that it already stores a credential from `excludeList`, it returns `CTAP2_ERR_CREDENTIAL_EXCLUDED`.

In Firefox, we need to show a prompt that guides the user towards retrying with another authenticator when we see `CTAP2_ERR_CREDENTIAL_EXCLUDED` ([Bug 1831392](https://bugzilla.mozilla.org/show_bug.cgi?id=1831392)). This patch exposes a top-level error code which we can catch in `authrs_bridge`.