### PR TITLE
Avoid dropping reserved / unknown authenticator data flags

### DIFF
--- a/src/ctap2/attestation.rs
+++ b/src/ctap2/attestation.rs
@@ -203,9 +203,15 @@ fn parse_attested_cred_data(
 }
 
 bitflags! {
+    // Defining an exhaustive list of flags here ensures that `from_bits_truncate` is lossless and
+    // that `from_bits` never returns None.
     pub struct AuthenticatorDataFlags: u8 {
         const USER_PRESENT = 0x01;
+        const RESERVED_1 = 0x02;
         const USER_VERIFIED = 0x04;
+        const RESERVED_3 = 0x08;
+        const RESERVED_4 = 0x10;
+        const RESERVED_5 = 0x20;
         const ATTESTED = 0x40;
         const EXTENSION_DATA = 0x80;
     }
@@ -224,8 +230,7 @@ fn parse_ad(input: &[u8]) -> IResult<&[u8], AuthenticatorData, NomError<&[u8]>> 
     let (rest, rp_id_hash_res) = map(take(32u8), RpIdHash::from)(input)?;
     // We can unwrap here, since we _know_ the input to from() will be 32 bytes or error out before calling from()
     let rp_id_hash = rp_id_hash_res.unwrap();
-    // be conservative, there is a couple of reserved values in
-    // AuthenticatorDataFlags, just truncate the one we don't know
+    // preserve the flags, even if some reserved values are set.
     let (rest, flags) = map(be_u8, AuthenticatorDataFlags::from_bits_truncate)(rest)?;
     let (rest, counter) = be_u32(rest)?;
     let (rest, credential_data) = cond(
@@ -839,5 +844,17 @@ mod test {
         let result = AAGuid::from(&input).expect("Failed to parse AAGuid");
         let res_str = format!("{result:?}");
         assert_eq!(expected, &res_str);
+    }
+
+    #[test]
+    fn test_ad_flags_from_bits() {
+        // Check that AuthenticatorDataFlags is defined on the entire u8 range and that
+        // `from_bits_truncate` is lossless
+        for x in 0..=u8::MAX {
+            assert_eq!(
+                AuthenticatorDataFlags::from_bits(x),
+                Some(AuthenticatorDataFlags::from_bits_truncate(x))
+            );
+        }
     }
 }


### PR DESCRIPTION
When re-packaging `U2F_AUTHENTICATE` responses into CTAP2 `GetAssertion` responses we were only copying the lowest bit of the user presence byte. While all of the other bits SHALL be 0 according to the CTAP1 spec, the CTAP2 spec says we should "Copy bits 0 (the UP bit) and bit 1 from the CTAP1/U2F response user presence byte to bits 0 and 1 of the CTAP2 flags, respectively. Set all other bits of flags to zero".