### PR TITLE
Add StatusUpdate::PresenceRequired

### DIFF
--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -102,6 +102,9 @@ fn main() {
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
                 println!("STATUS: Continuing with device: {dev_info}");
             }
+            Ok(StatusUpdate::PresenceRequired) => {
+                println!("STATUS: waiting for user presence");
+            }
             Ok(StatusUpdate::PinUvError(StatusPinUv::PinRequired(sender))) => {
                 let raw_pin =
                     rpassword::prompt_password_stderr("Enter PIN: ").expect("Failed to read PIN");

--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -65,6 +65,9 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
                 println!("STATUS: Continuing with device: {dev_info}");
             }
+            Ok(StatusUpdate::PresenceRequired) => {
+                println!("STATUS: waiting for user presence");
+            }
             Ok(StatusUpdate::PinUvError(StatusPinUv::PinRequired(sender))) => {
                 let raw_pin =
                     rpassword::prompt_password_stderr("Enter PIN: ").expect("Failed to read PIN");
@@ -257,6 +260,9 @@ fn main() {
             }
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
                 println!("STATUS: Continuing with device: {dev_info}");
+            }
+            Ok(StatusUpdate::PresenceRequired) => {
+                println!("STATUS: waiting for user presence");
             }
             Ok(StatusUpdate::PinUvError(StatusPinUv::PinRequired(sender))) => {
                 let raw_pin =

--- a/examples/interactive_management.rs
+++ b/examples/interactive_management.rs
@@ -119,6 +119,9 @@ fn interactive_status_callback(status_rx: Receiver<StatusUpdate>) {
                 println!("STATUS: Please select a device by touching one of them.");
             }
             Ok(StatusUpdate::DeviceSelected(_dev_info)) => {}
+            Ok(StatusUpdate::PresenceRequired) => {
+                println!("STATUS: waiting for user presence");
+            }
             Ok(StatusUpdate::PinUvError(..)) => {
                 println!("STATUS: Pin Error!");
             }

--- a/examples/reset.rs
+++ b/examples/reset.rs
@@ -107,6 +107,9 @@ fn main() {
             }
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
                 println!("STATUS: Continuing with device: {dev_info}");
+            }
+            Ok(StatusUpdate::PresenceRequired) => {
+                println!("STATUS: waiting for user presence");
                 break;
             }
             Ok(StatusUpdate::PinUvError(..)) => panic!("Reset should never ask for a PIN!"),

--- a/examples/set_pin.rs
+++ b/examples/set_pin.rs
@@ -88,6 +88,9 @@ fn main() {
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
                 println!("STATUS: Continuing with device: {dev_info}");
             }
+            Ok(StatusUpdate::PresenceRequired) => {
+                println!("STATUS: waiting for user presence");
+            }
             Ok(StatusUpdate::PinUvError(StatusPinUv::PinRequired(sender))) => {
                 let raw_pin =
                     rpassword::prompt_password_stderr("Enter PIN: ").expect("Failed to read PIN");

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -95,6 +95,9 @@ fn main() {
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
                 println!("STATUS: Continuing with device: {dev_info}");
             }
+            Ok(StatusUpdate::PresenceRequired) => {
+                println!("STATUS: waiting for user presence");
+            }
             Ok(StatusUpdate::PinUvError(StatusPinUv::PinRequired(sender))) => {
                 let raw_pin =
                     rpassword::prompt_password_stderr("Enter PIN: ").expect("Failed to read PIN");

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -607,6 +607,7 @@ impl StateMachine {
                             // Now we need to send a dummy registration request, to make the token blink
                             // Spec says "dummy appid and invalid challenge". We use the same, as we do for
                             // making the token blink upon device selection.
+                            send_status(&status, crate::StatusUpdate::PresenceRequired);
                             let msg = dummy_make_credentials_cmd();
                             let _ = dev.send_msg_cancellable(&msg, alive); // Ignore answer, return "CredentialExcluded"
                             callback.call(Err(HIDError::Command(CommandError::StatusCode(
@@ -621,6 +622,7 @@ impl StateMachine {
                     debug!("------------------------------------------------------------------");
                     debug!("{makecred:?} using {pin_uv_auth_result:?}");
                     debug!("------------------------------------------------------------------");
+                    send_status(&status, crate::StatusUpdate::PresenceRequired);
                     let resp = dev.send_msg_cancellable(&makecred, alive);
                     if resp.is_ok() {
                         send_status(
@@ -877,6 +879,7 @@ impl StateMachine {
                     // If the incoming list was not empty, but the filtered list is, we have to error out
                     if !original_allow_list_was_empty && get_assertion.allow_list.is_empty() {
                         // We have to collect a user interaction
+                        send_status(&status, crate::StatusUpdate::PresenceRequired);
                         let msg = dummy_make_credentials_cmd();
                         let _ = dev.send_msg_cancellable(&msg, alive); // Ignore answer, return "NoCredentials"
                         callback.call(Err(HIDError::Command(CommandError::StatusCode(
@@ -890,7 +893,7 @@ impl StateMachine {
                     debug!("------------------------------------------------------------------");
                     debug!("{get_assertion:?} using {pin_uv_auth_result:?}");
                     debug!("------------------------------------------------------------------");
-
+                    send_status(&status, crate::StatusUpdate::PresenceRequired);
                     let mut resp = dev.send_msg_cancellable(&get_assertion, alive);
                     if resp.is_err() {
                         // Retry with a different RP ID if one was supplied. This is intended to be
@@ -995,10 +998,11 @@ impl StateMachine {
     ) {
         let reset = Reset {};
         info!("Device {:?} continues with the reset process", dev.id());
+
         debug!("------------------------------------------------------------------");
         debug!("{:?}", reset);
         debug!("------------------------------------------------------------------");
-
+        send_status(&status, crate::StatusUpdate::PresenceRequired);
         let resp = dev.send_cbor_cancellable(&reset, keep_alive);
         if resp.is_ok() {
             send_status(
@@ -1245,6 +1249,8 @@ impl StateMachine {
                         .unwrap_or(false) /* no match on failure */
                 });
 
+                send_status(&status, crate::StatusUpdate::PresenceRequired);
+
                 while alive() {
                     if excluded {
                         let blank = vec![0u8; PARAMETER_SIZE];
@@ -1362,6 +1368,8 @@ impl StateMachine {
                         dev_info: dev.get_device_info(),
                     },
                 );
+
+                send_status(&status, crate::StatusUpdate::PresenceRequired);
 
                 'outer: while alive() {
                     // If the device matches none of the given key handles

--- a/src/status_update.rs
+++ b/src/status_update.rs
@@ -59,6 +59,8 @@ pub enum StatusUpdate {
     DeviceAvailable { dev_info: u2ftypes::U2FDeviceInfo },
     /// Device got removed
     DeviceUnavailable { dev_info: u2ftypes::U2FDeviceInfo },
+    /// We're waiting for the user to touch their token
+    PresenceRequired,
     /// We successfully finished the register or sign request
     Success { dev_info: u2ftypes::U2FDeviceInfo },
     /// Sent if a PIN is needed (or was wrong), or some other kind of PIN-related


### PR DESCRIPTION
`StatusUpdate::PresenceRequired` signals to the application that it's time to show a "Touch your security key" prompt. Previously, in Firefox, we showed those prompts upon receiving `StatusUpdate::DeviceSelected(..)`, which would sometimes cause the "Touch your security key" prompt to be shown briefly before being overridden by a PIN/UV prompt.