### PR TITLE
Don't assume CTAP2 support based on CBOR capability flag

### DIFF
--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -246,13 +246,10 @@ impl StateMachine {
         cmd.set_uv_option(None);
 
         // CTAP1/U2F-only devices do not support user verification, so we skip it
-        if !dev.supports_ctap2() {
-            return Ok(PinUvAuthResult::DeviceIsCtap1);
-        }
-
-        let info = dev
-            .get_authenticator_info()
-            .ok_or(AuthenticatorError::HIDError(HIDError::DeviceNotInitialized))?;
+        let info = match dev.get_authenticator_info() {
+            Some(info) => info,
+            None => return Ok(PinUvAuthResult::DeviceIsCtap1),
+        };
 
         // Only use UV, if the device supports it and we don't skip it
         // which happens as a fallback, if UV-usage failed too many times

--- a/src/transport/hid.rs
+++ b/src/transport/hid.rs
@@ -1,4 +1,4 @@
-use crate::consts::{Capability, HIDCmd, CID_BROADCAST};
+use crate::consts::{HIDCmd, CID_BROADCAST};
 use crate::crypto::SharedSecret;
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::{errors::HIDError, Nonce};
@@ -30,16 +30,6 @@ where
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo);
     fn set_shared_secret(&mut self, secret: SharedSecret);
     fn get_shared_secret(&self) -> Option<&SharedSecret>;
-
-    fn supports_ctap1(&self) -> bool {
-        // CAPABILITY_NMSG:
-        // If set to 1, authenticator DOES NOT implement U2FHID_MSG function
-        !self.get_device_info().cap_flags.contains(Capability::NMSG)
-    }
-
-    fn supports_ctap2(&self) -> bool {
-        self.get_device_info().cap_flags.contains(Capability::CBOR)
-    }
 
     // Initialize on a protocol-level
     fn initialize(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
@@ -74,7 +64,7 @@ where
             .get_property("Product")
             .unwrap_or_else(|_| String::from("Unknown Device"));
 
-        self.set_device_info(U2FDeviceInfo {
+        let info = U2FDeviceInfo {
             vendor_name: vendor.as_bytes().to_vec(),
             device_name: product.as_bytes().to_vec(),
             version_interface: rsp.version_interface,
@@ -82,7 +72,9 @@ where
             version_minor: rsp.version_minor,
             version_build: rsp.version_build,
             cap_flags: rsp.cap_flags,
-        });
+        };
+        debug!("{:?}: {:?}", self.id(), info);
+        self.set_device_info(info);
 
         // A CTAPHID host SHALL accept a response size that is longer than the
         // anticipated size to allow for future extensions of the protocol, yet
@@ -116,7 +108,7 @@ where
 
         // If this is a CTAP2 device we can tell the authenticator to cancel the transaction on its
         // side as well. There's nothing to do for U2F/CTAP1 devices.
-        if self.supports_ctap2() {
+        if self.get_authenticator_info().is_some() {
             self.u2f_write(u8::from(HIDCmd::Cancel), &[])?;
         }
         // For CTAP2 devices we expect to read

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,4 +1,4 @@
-use crate::consts::HIDCmd;
+use crate::consts::{Capability, HIDCmd};
 use crate::crypto::{PinUvAuthProtocol, PinUvAuthToken, SharedSecret};
 use crate::ctap2::commands::client_pin::{
     GetKeyAgreement, GetPinToken, GetPinUvAuthTokenUsingPinWithPermissions,
@@ -100,7 +100,7 @@ pub trait FidoDevice: HIDDevice {
             return Err(HIDError::DeviceNotInitialized);
         }
 
-        if self.supports_ctap2() {
+        if self.get_authenticator_info().is_some() {
             self.send_cbor_cancellable(msg, keep_alive)
         } else {
             self.send_ctap1_cancellable(msg, keep_alive)
@@ -185,20 +185,29 @@ pub trait FidoDevice: HIDDevice {
     // This is ugly as we have 2 init-functions now, but the fastest way currently.
     fn init(&mut self, nonce: Nonce) -> Result<(), HIDError> {
         <Self as HIDDevice>::initialize(self, nonce)?;
-        // TODO(baloo): this logic should be moved to
-        //              transport/mod.rs::Device trait
-        if self.supports_ctap2() {
-            let command = GetInfo::default();
-            let info = self.send_cbor(&command)?;
-            debug!("{:?} infos: {:?}", self.id(), info);
 
-            self.set_authenticator_info(info);
+        // If the device has the CBOR capability flag, then we'll check
+        // for CTAP2 support by sending an authenticatorGetInfo command.
+        // We're not aware of any CTAP2 devices that fail to set the CBOR
+        // capability flag, but we may need to rework this in the future.
+        if self.get_device_info().cap_flags.contains(Capability::CBOR) {
+            let command = GetInfo::default();
+            if let Ok(info) = self.send_cbor(&command) {
+                debug!("{:?}: {:?}", self.id(), info);
+                if info.max_supported_version() != AuthenticatorVersion::U2F_V2 {
+                    // Device supports CTAP2
+                    self.set_authenticator_info(info);
+                    return Ok(());
+                }
+            }
+            // An error from GetInfo might indicate that we're talking
+            // to a CTAP1 device that mistakenly claimed the CBOR capability,
+            // so we fallthrough here.
         }
-        if self.supports_ctap1() {
-            let command = GetVersion::default();
-            // We don't really use the result here
-            self.send_ctap1(&command)?;
-        }
+        // We want to return an error here if this device doesn't support CTAP1,
+        // so we send a U2F_VERSION command.
+        let command = GetVersion::default();
+        self.send_ctap1(&command)?;
         Ok(())
     }
 
@@ -246,13 +255,12 @@ pub trait FidoDevice: HIDDevice {
     }
 
     fn establish_shared_secret(&mut self) -> Result<SharedSecret, HIDError> {
-        if !self.supports_ctap2() {
-            return Err(HIDError::UnsupportedCommand);
-        }
+        // CTAP1 devices don't support establishing a shared secret
+        let info = match self.get_authenticator_info() {
+            Some(info) => info,
+            None => return Err(HIDError::UnsupportedCommand),
+        };
 
-        let info = self
-            .get_authenticator_info()
-            .ok_or(HIDError::DeviceNotInitialized)?;
         let pin_protocol = PinUvAuthProtocol::try_from(info)?;
 
         // Not reusing the shared secret here, if it exists, since we might start again


### PR DESCRIPTION
Will Smart from Yubico gathered some diagnostic information for [Bug 1824811](https://bugzilla.mozilla.org/show_bug.cgi?id=1824811) using a YK4 FIPS. A log he sent me shows authenticator-rs sending an `authenticatorGetInfo` command to the device. Based on our current implementation of `FidoDevice::init`, this implies that the device has `CAPABILITY_CBOR` flag set.

So, `CAPABILITY_CBOR` isn't a reliable indicator of CTAP2 support. With this patch we'll assume that we're talking to a CTAP1 device until we get a successful response to `authenticatorGetInfo`. The main change is in falling through to `GetVersion` after a failure in `GetInfo` in `FidoDevice::init`. I also removed the (essentially unused) `FidoDevice::supports_ctap1` and `supports_ctap2` functions as it's better to just check whether `FidoDevice::get_authenticator_info` is `Some`.