### PR TITLE
Decouple the abstract FidoDevice trait from HIDDevice and U2FDevice

### DIFF
--- a/src/ctap2/commands/client_pin.rs
+++ b/src/ctap2/commands/client_pin.rs
@@ -5,7 +5,7 @@
 use super::{get_info::AuthenticatorInfo, Command, CommandError, RequestCtap2, StatusCode};
 use crate::crypto::{COSEKey, CryptoError, PinUvAuthProtocol, PinUvAuthToken, SharedSecret};
 use crate::transport::errors::HIDError;
-use crate::u2ftypes::U2FDevice;
+use crate::transport::FidoDevice;
 use serde::{
     de::{Error as SerdeError, IgnoredAny, MapAccess, Visitor},
     ser::SerializeMap,
@@ -625,14 +625,11 @@ where
         Ok(output)
     }
 
-    fn handle_response_ctap2<Dev>(
+    fn handle_response_ctap2<Dev: FidoDevice>(
         &self,
         _dev: &mut Dev,
         input: &[u8],
-    ) -> Result<Self::Output, HIDError>
-    where
-        Dev: U2FDevice,
-    {
+    ) -> Result<Self::Output, HIDError> {
         trace!("Client pin subcomand response:{:04X?}", &input);
         if input.is_empty() {
             return Err(CommandError::InputTooSmall.into());

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -33,7 +33,6 @@ use serde::{
 use serde_bytes::ByteBuf;
 use serde_cbor::{de::from_slice, ser, Value};
 use std::fmt;
-use std::io;
 
 #[derive(Clone, Copy, Debug, Serialize)]
 #[cfg_attr(test, derive(Deserialize))]
@@ -381,14 +380,11 @@ impl RequestCtap2 for GetAssertion {
         Ok(ser::to_vec(&self).map_err(CommandError::Serializing)?)
     }
 
-    fn handle_response_ctap2<Dev>(
+    fn handle_response_ctap2<Dev: FidoDevice>(
         &self,
         dev: &mut Dev,
         input: &[u8],
-    ) -> Result<Self::Output, HIDError>
-    where
-        Dev: FidoDevice + io::Read + io::Write + fmt::Debug,
-    {
+    ) -> Result<Self::Output, HIDError> {
         if input.is_empty() {
             return Err(CommandError::InputTooSmall.into());
         }
@@ -617,7 +613,7 @@ pub mod test {
     use crate::transport::device_selector::Device;
     use crate::transport::hid::HIDDevice;
     use crate::transport::FidoDevice;
-    use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
+    use crate::u2ftypes::U2FDeviceInfo;
     use rand::{thread_rng, RngCore};
 
     #[test]

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -2,7 +2,7 @@ use super::{Command, CommandError, RequestCtap2, StatusCode};
 use crate::ctap2::attestation::AAGuid;
 use crate::ctap2::server::PublicKeyCredentialParameters;
 use crate::transport::errors::HIDError;
-use crate::u2ftypes::U2FDevice;
+use crate::transport::FidoDevice;
 use serde::{
     de::{Error as SError, IgnoredAny, MapAccess, Visitor},
     Deserialize, Deserializer, Serialize,
@@ -25,14 +25,11 @@ impl RequestCtap2 for GetInfo {
         Ok(Vec::new())
     }
 
-    fn handle_response_ctap2<Dev>(
+    fn handle_response_ctap2<Dev: FidoDevice>(
         &self,
         _dev: &mut Dev,
         input: &[u8],
-    ) -> Result<Self::Output, HIDError>
-    where
-        Dev: U2FDevice,
-    {
+    ) -> Result<Self::Output, HIDError> {
         if input.is_empty() {
             return Err(CommandError::InputTooSmall.into());
         }
@@ -534,7 +531,6 @@ pub mod tests {
     use crate::transport::device_selector::Device;
     use crate::transport::platform::device::IN_HID_RPT_SIZE;
     use crate::transport::{hid::HIDDevice, FidoDevice, Nonce};
-    use crate::u2ftypes::U2FDevice;
     use rand::{thread_rng, RngCore};
     use serde_cbor::de::from_slice;
 

--- a/src/ctap2/commands/get_next_assertion.rs
+++ b/src/ctap2/commands/get_next_assertion.rs
@@ -1,7 +1,7 @@
 use super::{Command, CommandError, RequestCtap2, StatusCode};
 use crate::ctap2::commands::get_assertion::GetAssertionResponse;
 use crate::transport::errors::HIDError;
-use crate::u2ftypes::U2FDevice;
+use crate::transport::FidoDevice;
 use serde_cbor::{de::from_slice, Value};
 
 #[derive(Debug)]
@@ -18,14 +18,11 @@ impl RequestCtap2 for GetNextAssertion {
         Ok(Vec::new())
     }
 
-    fn handle_response_ctap2<Dev>(
+    fn handle_response_ctap2<Dev: FidoDevice>(
         &self,
         _dev: &mut Dev,
         input: &[u8],
-    ) -> Result<Self::Output, HIDError>
-    where
-        Dev: U2FDevice,
-    {
+    ) -> Result<Self::Output, HIDError> {
         if input.is_empty() {
             return Err(CommandError::InputTooSmall.into());
         }

--- a/src/ctap2/commands/get_version.rs
+++ b/src/ctap2/commands/get_version.rs
@@ -51,7 +51,6 @@ pub mod tests {
     use crate::consts::{Capability, HIDCmd, CID_BROADCAST, SW_NO_ERROR};
     use crate::transport::device_selector::Device;
     use crate::transport::{hid::HIDDevice, FidoDevice, Nonce};
-    use crate::u2ftypes::U2FDevice;
     use rand::{thread_rng, RngCore};
 
     #[test]

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -20,7 +20,8 @@ use crate::ctap2::server::{
 };
 use crate::errors::AuthenticatorError;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
-use crate::u2ftypes::{CTAP1RequestAPDU, U2FDevice};
+use crate::transport::FidoDevice;
+use crate::u2ftypes::CTAP1RequestAPDU;
 use nom::{
     bytes::complete::{tag, take},
     error::VerboseError,
@@ -34,8 +35,6 @@ use serde::{
     Serialize, Serializer,
 };
 use serde_cbor::{self, de::from_slice, ser, Value};
-use std::fmt;
-use std::io;
 
 #[derive(Debug)]
 pub struct MakeCredentialsResult(pub AttestationObject);
@@ -374,14 +373,11 @@ impl RequestCtap2 for MakeCredentials {
         Ok(ser::to_vec(&self).map_err(CommandError::Serializing)?)
     }
 
-    fn handle_response_ctap2<Dev>(
+    fn handle_response_ctap2<Dev: FidoDevice>(
         &self,
         _dev: &mut Dev,
         input: &[u8],
-    ) -> Result<Self::Output, HIDError>
-    where
-        Dev: U2FDevice + io::Read + io::Write + fmt::Debug,
-    {
+    ) -> Result<Self::Output, HIDError> {
         if input.is_empty() {
             return Err(HIDError::Command(CommandError::InputTooSmall));
         }

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -10,7 +10,6 @@ use serde_cbor::{error::Error as CborError, Value};
 use serde_json as json;
 use std::error::Error as StdErrorT;
 use std::fmt;
-use std::io::{Read, Write};
 
 pub(crate) mod client_pin;
 pub(crate) mod get_assertion;
@@ -80,13 +79,11 @@ pub trait RequestCtap2: fmt::Debug {
 
     fn wire_format(&self) -> Result<Vec<u8>, HIDError>;
 
-    fn handle_response_ctap2<Dev>(
+    fn handle_response_ctap2<Dev: FidoDevice>(
         &self,
         dev: &mut Dev,
         input: &[u8],
-    ) -> Result<Self::Output, HIDError>
-    where
-        Dev: FidoDevice + Read + Write + fmt::Debug;
+    ) -> Result<Self::Output, HIDError>;
 }
 
 #[derive(Debug, Clone)]

--- a/src/ctap2/commands/reset.rs
+++ b/src/ctap2/commands/reset.rs
@@ -1,6 +1,6 @@
 use super::{Command, CommandError, RequestCtap2, StatusCode};
 use crate::transport::errors::HIDError;
-use crate::u2ftypes::U2FDevice;
+use crate::transport::FidoDevice;
 use serde_cbor::{de::from_slice, Value};
 
 #[derive(Debug, Default)]
@@ -17,14 +17,11 @@ impl RequestCtap2 for Reset {
         Ok(Vec::new())
     }
 
-    fn handle_response_ctap2<Dev>(
+    fn handle_response_ctap2<Dev: FidoDevice>(
         &self,
         _dev: &mut Dev,
         input: &[u8],
-    ) -> Result<Self::Output, HIDError>
-    where
-        Dev: U2FDevice,
-    {
+    ) -> Result<Self::Output, HIDError> {
         if input.is_empty() {
             return Err(CommandError::InputTooSmall.into());
         }
@@ -51,7 +48,6 @@ pub mod tests {
     use crate::consts::HIDCmd;
     use crate::transport::device_selector::Device;
     use crate::transport::{hid::HIDDevice, FidoDevice};
-    use crate::u2ftypes::U2FDevice;
     use rand::{thread_rng, RngCore};
     use serde_cbor::{de::from_slice, Value};
 

--- a/src/ctap2/commands/selection.rs
+++ b/src/ctap2/commands/selection.rs
@@ -1,6 +1,6 @@
 use super::{Command, CommandError, RequestCtap2, StatusCode};
 use crate::transport::errors::HIDError;
-use crate::u2ftypes::U2FDevice;
+use crate::transport::FidoDevice;
 use serde_cbor::{de::from_slice, Value};
 
 #[derive(Debug, Default)]
@@ -17,14 +17,11 @@ impl RequestCtap2 for Selection {
         Ok(Vec::new())
     }
 
-    fn handle_response_ctap2<Dev>(
+    fn handle_response_ctap2<Dev: FidoDevice>(
         &self,
         _dev: &mut Dev,
         input: &[u8],
-    ) -> Result<Self::Output, HIDError>
-    where
-        Dev: U2FDevice,
-    {
+    ) -> Result<Self::Output, HIDError> {
         if input.is_empty() {
             return Err(CommandError::InputTooSmall.into());
         }
@@ -51,7 +48,6 @@ pub mod tests {
     use crate::consts::HIDCmd;
     use crate::transport::device_selector::Device;
     use crate::transport::{hid::HIDDevice, FidoDevice};
-    use crate::u2ftypes::U2FDevice;
     use rand::{thread_rng, RngCore};
     use serde_cbor::{de::from_slice, Value};
 

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -37,7 +37,6 @@ use crate::transport::device_selector::{Device, DeviceSelectorEvent};
 
 use crate::transport::{errors::HIDError, hid::HIDDevice, FidoDevice};
 
-use crate::u2ftypes::U2FDevice;
 use crate::{send_status, RegisterResult, SignResult, StatusPinUv, StatusUpdate};
 use std::sync::mpsc::{channel, RecvError, Sender};
 use std::thread;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,13 @@
 #[macro_use]
 mod util;
 
-#[cfg(any(target_os = "linux"))]
+#[cfg(target_os = "linux")]
 extern crate libudev;
 
-#[cfg(any(target_os = "freebsd"))]
+#[cfg(target_os = "freebsd")]
 extern crate devd_rs;
 
-#[cfg(any(target_os = "macos"))]
+#[cfg(target_os = "macos")]
 extern crate core_foundation;
 
 extern crate libc;

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -23,7 +23,6 @@ use crate::transport::device_selector::{
 use crate::transport::platform::transaction::Transaction;
 use crate::transport::{hid::HIDDevice, FidoDevice, Nonce};
 use crate::u2fprotocol::{u2f_init_device, u2f_is_keyhandle_valid, u2f_register, u2f_sign};
-use crate::u2ftypes::U2FDevice;
 use crate::{
     send_status, AuthenticatorTransports, InteractiveRequest, KeyHandle, RegisterFlags,
     RegisterResult, SignFlags, SignResult,

--- a/src/transport/device_selector.rs
+++ b/src/transport/device_selector.rs
@@ -1,13 +1,11 @@
 use crate::transport::hid::HIDDevice;
+
 pub use crate::transport::platform::device::Device;
+
 use runloop::RunLoop;
 use std::collections::{HashMap, HashSet};
 use std::sync::mpsc::{channel, RecvTimeoutError, Sender};
 use std::time::Duration;
-
-// This import is used, but Rust 1.68 gives a warning
-#[allow(unused_imports)]
-use crate::u2ftypes::U2FDevice;
 
 pub type DeviceID = <Device as HIDDevice>::Id;
 pub type DeviceBuildParameters = <Device as HIDDevice>::BuildParameters;
@@ -186,6 +184,7 @@ pub mod tests {
     use crate::{
         consts::Capability,
         ctap2::commands::get_info::{AuthenticatorInfo, AuthenticatorOptions},
+        transport::FidoDevice,
         u2ftypes::U2FDeviceInfo,
     };
 

--- a/src/transport/freebsd/device.rs
+++ b/src/transport/freebsd/device.rs
@@ -8,8 +8,8 @@ use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::uhid;
-use crate::transport::{FidoDevice, HIDError, SharedSecret};
-use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
+use crate::transport::{FidoDevice, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::from_unix_result;
 use crate::util::io_err;
 use std::ffi::{CString, OsString};
@@ -121,38 +121,6 @@ impl Write for Device {
     }
 }
 
-impl U2FDevice for Device {
-    fn get_cid(&self) -> &[u8; 4] {
-        &self.cid
-    }
-
-    fn set_cid(&mut self, cid: [u8; 4]) {
-        self.cid = cid;
-    }
-
-    fn in_rpt_size(&self) -> usize {
-        MAX_HID_RPT_SIZE
-    }
-
-    fn out_rpt_size(&self) -> usize {
-        MAX_HID_RPT_SIZE
-    }
-
-    fn get_property(&self, _prop_name: &str) -> io::Result<String> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
-    }
-
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
-    }
-
-    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
-        self.dev_info = Some(dev_info);
-    }
-}
-
 impl HIDDevice for Device {
     type BuildParameters = OsString;
     type Id = OsString;
@@ -178,13 +146,58 @@ impl HIDDevice for Device {
         }
     }
 
+    fn id(&self) -> Self::Id {
+        self.path.clone()
+    }
+
+    fn get_cid(&self) -> &[u8; 4] {
+        &self.cid
+    }
+
+    fn set_cid(&mut self, cid: [u8; 4]) {
+        self.cid = cid;
+    }
+
+    fn in_rpt_size(&self) -> usize {
+        MAX_HID_RPT_SIZE
+    }
+
+    fn out_rpt_size(&self) -> usize {
+        MAX_HID_RPT_SIZE
+    }
+
+    fn get_property(&self, _prop_name: &str) -> io::Result<String> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
+    }
+}
+
+impl FidoDevice for Device {
+    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
+        HIDDevice::pre_init(self, noncecmd)
+    }
+
+    fn sendrecv(
+        &mut self,
+        cmd: HIDCmd,
+        send: &[u8],
+        keep_alive: &dyn Fn() -> bool,
+    ) -> io::Result<(HIDCmd, Vec<u8>)> {
+        HIDDevice::sendrecv(self, cmd, send, keep_alive)
+    }
+
+    fn get_device_info(&self) -> U2FDeviceInfo {
+        // unwrap is okay, as dev_info must have already been set, else
+        // a programmer error
+        self.dev_info.clone().unwrap()
+    }
+
+    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
+        self.dev_info = Some(dev_info);
+    }
+
     fn initialized(&self) -> bool {
         // During successful init, the broadcast channel id gets repplaced by an actual one
         self.cid != CID_BROADCAST
-    }
-
-    fn id(&self) -> Self::Id {
-        self.path.clone()
     }
 
     fn is_u2f(&mut self) -> bool {
@@ -213,5 +226,3 @@ impl HIDDevice for Device {
         self.authenticator_info = Some(authenticator_info);
     }
 }
-
-impl FidoDevice for Device {}

--- a/src/transport/hidproto.rs
+++ b/src/transport/hidproto.rs
@@ -9,12 +9,12 @@
     allow(clippy::cast_lossless, clippy::needless_lifetimes)
 )]
 
-#[cfg(any(target_os = "linux"))]
+#[cfg(target_os = "linux")]
 use std::io;
 use std::mem;
 
 use crate::consts::{FIDO_USAGE_PAGE, FIDO_USAGE_U2FHID};
-#[cfg(any(target_os = "linux"))]
+#[cfg(target_os = "linux")]
 use crate::consts::{INIT_HEADER_SIZE, MAX_HID_RPT_SIZE};
 
 // The 4 MSBs (the tag) are set when it's a long item.
@@ -181,7 +181,7 @@ pub fn has_fido_usage(desc: ReportDescriptor) -> bool {
     false
 }
 
-#[cfg(any(target_os = "linux"))]
+#[cfg(target_os = "linux")]
 pub fn read_hid_rpt_sizes(desc: ReportDescriptor) -> io::Result<(usize, usize)> {
     let mut in_rpt_count = None;
     let mut out_rpt_count = None;

--- a/src/transport/openbsd/device.rs
+++ b/src/transport/openbsd/device.rs
@@ -7,8 +7,8 @@ use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::monitor::WrappedOpenDevice;
-use crate::transport::{FidoDevice, HIDError, SharedSecret};
-use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
+use crate::transport::{FidoDevice, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::{from_unix_result, io_err};
 use std::ffi::{CString, OsString};
 use std::hash::{Hash, Hasher};
@@ -105,38 +105,6 @@ impl Write for Device {
     }
 }
 
-impl U2FDevice for Device {
-    fn get_cid(&self) -> &[u8; 4] {
-        &self.cid
-    }
-
-    fn set_cid(&mut self, cid: [u8; 4]) {
-        self.cid = cid;
-    }
-
-    fn in_rpt_size(&self) -> usize {
-        self.in_rpt_size
-    }
-
-    fn out_rpt_size(&self) -> usize {
-        self.out_rpt_size
-    }
-
-    fn get_property(&self, _prop_name: &str) -> io::Result<String> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
-    }
-
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
-    }
-
-    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
-        self.dev_info = Some(dev_info);
-    }
-}
-
 impl HIDDevice for Device {
     type BuildParameters = WrappedOpenDevice;
     type Id = OsString;
@@ -161,13 +129,58 @@ impl HIDDevice for Device {
         }
     }
 
+    fn id(&self) -> Self::Id {
+        self.path.clone()
+    }
+
+    fn get_cid(&self) -> &[u8; 4] {
+        &self.cid
+    }
+
+    fn set_cid(&mut self, cid: [u8; 4]) {
+        self.cid = cid;
+    }
+
+    fn in_rpt_size(&self) -> usize {
+        self.in_rpt_size
+    }
+
+    fn out_rpt_size(&self) -> usize {
+        self.out_rpt_size
+    }
+
+    fn get_property(&self, _prop_name: &str) -> io::Result<String> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
+    }
+}
+
+impl FidoDevice for Device {
+    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
+        HIDDevice::pre_init(self, noncecmd)
+    }
+
+    fn sendrecv(
+        &mut self,
+        cmd: HIDCmd,
+        send: &[u8],
+        keep_alive: &dyn Fn() -> bool,
+    ) -> io::Result<(HIDCmd, Vec<u8>)> {
+        HIDDevice::sendrecv(self, cmd, send, keep_alive)
+    }
+
+    fn get_device_info(&self) -> U2FDeviceInfo {
+        // unwrap is okay, as dev_info must have already been set, else
+        // a programmer error
+        self.dev_info.clone().unwrap()
+    }
+
+    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
+        self.dev_info = Some(dev_info);
+    }
+
     fn initialized(&self) -> bool {
         // During successful init, the broadcast channel id gets repplaced by an actual one
         self.cid != CID_BROADCAST
-    }
-
-    fn id(&self) -> Self::Id {
-        self.path.clone()
     }
 
     fn is_u2f(&mut self) -> bool {
@@ -202,5 +215,3 @@ impl HIDDevice for Device {
         self.authenticator_info = Some(authenticator_info);
     }
 }
-
-impl FidoDevice for Device {}

--- a/src/transport/stub/device.rs
+++ b/src/transport/stub/device.rs
@@ -5,8 +5,8 @@
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::FidoDevice;
-use crate::transport::{HIDError, SharedSecret};
-use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
+use crate::transport::{HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::u2ftypes::U2FDeviceInfo;
 use std::hash::Hash;
 use std::io;
 use std::io::{Read, Write};
@@ -17,47 +17,17 @@ pub struct Device {}
 
 impl Read for Device {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        panic!("not implemented");
+        unimplemented!();
     }
 }
 
 impl Write for Device {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        panic!("not implemented");
+        unimplemented!();
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        panic!("not implemented");
-    }
-}
-
-impl U2FDevice for Device {
-    fn get_cid(&self) -> &[u8; 4] {
-        panic!("not implemented");
-    }
-
-    fn set_cid(&mut self, cid: [u8; 4]) {
-        panic!("not implemented");
-    }
-
-    fn in_rpt_size(&self) -> usize {
-        panic!("not implemented");
-    }
-
-    fn out_rpt_size(&self) -> usize {
-        panic!("not implemented");
-    }
-
-    fn get_property(&self, prop_name: &str) -> io::Result<String> {
-        panic!("not implemented")
-    }
-
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        panic!("not implemented")
-    }
-
-    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
-        panic!("not implemented")
+        unimplemented!();
     }
 }
 
@@ -69,16 +39,59 @@ impl HIDDevice for Device {
         unimplemented!();
     }
 
-    fn initialized(&self) -> bool {
-        unimplemented!();
-    }
-
     fn id(&self) -> Self::Id {
         unimplemented!()
     }
 
+    fn get_cid(&self) -> &[u8; 4] {
+        unimplemented!();
+    }
+
+    fn set_cid(&mut self, cid: [u8; 4]) {
+        unimplemented!();
+    }
+
+    fn in_rpt_size(&self) -> usize {
+        unimplemented!();
+    }
+
+    fn out_rpt_size(&self) -> usize {
+        unimplemented!();
+    }
+
+    fn get_property(&self, prop_name: &str) -> io::Result<String> {
+        unimplemented!();
+    }
+}
+
+impl FidoDevice for Device {
+    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
+        unimplemented!();
+    }
+
+    fn sendrecv(
+        &mut self,
+        cmd: HIDCmd,
+        send: &[u8],
+        keep_alive: &dyn Fn() -> bool,
+    ) -> io::Result<(HIDCmd, Vec<u8>)> {
+        unimplemented!();
+    }
+
+    fn initialized(&self) -> bool {
+        unimplemented!();
+    }
+
     fn is_u2f(&mut self) -> bool {
         unimplemented!()
+    }
+
+    fn get_device_info(&self) -> U2FDeviceInfo {
+        unimplemented!();
+    }
+
+    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
+        unimplemented!();
     }
 
     fn get_authenticator_info(&self) -> Option<&AuthenticatorInfo> {
@@ -97,5 +110,3 @@ impl HIDDevice for Device {
         unimplemented!()
     }
 }
-
-impl FidoDevice for Device {}

--- a/src/transport/windows/device.rs
+++ b/src/transport/windows/device.rs
@@ -6,8 +6,8 @@ use super::winapi::DeviceCapabilities;
 use crate::consts::{CID_BROADCAST, FIDO_USAGE_PAGE, FIDO_USAGE_U2FHID, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
-use crate::transport::{FidoDevice, HIDError, SharedSecret};
-use crate::u2ftypes::{U2FDevice, U2FDeviceInfo};
+use crate::transport::{FidoDevice, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::u2ftypes::U2FDeviceInfo;
 use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};
 use std::io::{self, Read, Write};
@@ -59,38 +59,6 @@ impl Write for Device {
     }
 }
 
-impl U2FDevice for Device {
-    fn get_cid(&self) -> &[u8; 4] {
-        &self.cid
-    }
-
-    fn set_cid(&mut self, cid: [u8; 4]) {
-        self.cid = cid;
-    }
-
-    fn in_rpt_size(&self) -> usize {
-        MAX_HID_RPT_SIZE
-    }
-
-    fn out_rpt_size(&self) -> usize {
-        MAX_HID_RPT_SIZE
-    }
-
-    fn get_property(&self, _prop_name: &str) -> io::Result<String> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
-    }
-
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
-    }
-
-    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
-        self.dev_info = Some(dev_info);
-    }
-}
-
 impl HIDDevice for Device {
     type BuildParameters = String;
     type Id = String;
@@ -118,13 +86,57 @@ impl HIDDevice for Device {
         }
     }
 
+    fn id(&self) -> Self::Id {
+        self.path.clone()
+    }
+    fn get_cid(&self) -> &[u8; 4] {
+        &self.cid
+    }
+
+    fn set_cid(&mut self, cid: [u8; 4]) {
+        self.cid = cid;
+    }
+
+    fn in_rpt_size(&self) -> usize {
+        MAX_HID_RPT_SIZE
+    }
+
+    fn out_rpt_size(&self) -> usize {
+        MAX_HID_RPT_SIZE
+    }
+
+    fn get_property(&self, _prop_name: &str) -> io::Result<String> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
+    }
+}
+
+impl FidoDevice for Device {
+    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
+        HIDDevice::pre_init(self, noncecmd)
+    }
+
+    fn sendrecv(
+        &mut self,
+        cmd: HIDCmd,
+        send: &[u8],
+        keep_alive: &dyn Fn() -> bool,
+    ) -> io::Result<(HIDCmd, Vec<u8>)> {
+        HIDDevice::sendrecv(self, cmd, send, keep_alive)
+    }
+
+    fn get_device_info(&self) -> U2FDeviceInfo {
+        // unwrap is okay, as dev_info must have already been set, else
+        // a programmer error
+        self.dev_info.clone().unwrap()
+    }
+
+    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
+        self.dev_info = Some(dev_info);
+    }
+
     fn initialized(&self) -> bool {
         // During successful init, the broadcast channel id gets repplaced by an actual one
         self.cid != CID_BROADCAST
-    }
-
-    fn id(&self) -> Self::Id {
-        self.path.clone()
     }
 
     fn is_u2f(&mut self) -> bool {
@@ -150,5 +162,3 @@ impl HIDDevice for Device {
         self.authenticator_info = Some(authenticator_info);
     }
 }
-
-impl FidoDevice for Device {}

--- a/src/u2ftypes.rs
+++ b/src/u2ftypes.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::consts::*;
+use crate::transport::hid::HIDDevice;
 use crate::util::io_err;
 use serde::Serialize;
 use std::{cmp, fmt, io, str};
@@ -18,33 +19,6 @@ pub fn trace_hex(data: &[u8]) {
     }
 }
 
-// Trait for representing U2F HID Devices. Requires getters/setters for the
-// channel ID, created during device initialization.
-pub trait U2FDevice {
-    fn get_cid(&self) -> &[u8; 4];
-    fn set_cid(&mut self, cid: [u8; 4]);
-
-    fn in_rpt_size(&self) -> usize;
-    fn in_init_data_size(&self) -> usize {
-        self.in_rpt_size() - INIT_HEADER_SIZE
-    }
-    fn in_cont_data_size(&self) -> usize {
-        self.in_rpt_size() - CONT_HEADER_SIZE
-    }
-
-    fn out_rpt_size(&self) -> usize;
-    fn out_init_data_size(&self) -> usize {
-        self.out_rpt_size() - INIT_HEADER_SIZE
-    }
-    fn out_cont_data_size(&self) -> usize {
-        self.out_rpt_size() - CONT_HEADER_SIZE
-    }
-
-    fn get_property(&self, prop_name: &str) -> io::Result<String>;
-    fn get_device_info(&self) -> U2FDeviceInfo;
-    fn set_device_info(&mut self, dev_info: U2FDeviceInfo);
-}
-
 // Init structure for U2F Communications. Tells the receiver what channel
 // communication is happening on, what command is running, and how much data to
 // expect to receive over all.
@@ -54,10 +28,7 @@ pub trait U2FDevice {
 pub struct U2FHIDInit {}
 
 impl U2FHIDInit {
-    pub fn read<T>(dev: &mut T) -> io::Result<(HIDCmd, Vec<u8>)>
-    where
-        T: U2FDevice + io::Read,
-    {
+    pub fn read<T: HIDDevice>(dev: &mut T) -> io::Result<(HIDCmd, Vec<u8>)> {
         let mut frame = vec![0u8; dev.in_rpt_size()];
         let mut count = dev.read(&mut frame)?;
 
@@ -74,16 +45,17 @@ impl U2FHIDInit {
         let cap = (frame[5] as usize) << 8 | (frame[6] as usize);
         let mut data = Vec::with_capacity(cap);
 
-        let len = cmp::min(cap, dev.in_init_data_size());
+        let len = if dev.in_rpt_size() >= INIT_HEADER_SIZE {
+            cmp::min(cap, dev.in_rpt_size() - INIT_HEADER_SIZE)
+        } else {
+            cap
+        };
         data.extend_from_slice(&frame[7..7 + len]);
 
         Ok((cmd, data))
     }
 
-    pub fn write<T>(dev: &mut T, cmd: u8, data: &[u8]) -> io::Result<usize>
-    where
-        T: U2FDevice + io::Write,
-    {
+    pub fn write<T: HIDDevice>(dev: &mut T, cmd: u8, data: &[u8]) -> io::Result<usize> {
         if data.len() > 0xffff {
             return Err(io_err("payload length > 2^16"));
         }
@@ -94,7 +66,11 @@ impl U2FHIDInit {
         frame[6] = (data.len() >> 8) as u8;
         frame[7] = data.len() as u8;
 
-        let count = cmp::min(data.len(), dev.out_init_data_size());
+        let count = if dev.out_rpt_size() >= INIT_HEADER_SIZE {
+            cmp::min(data.len(), dev.out_rpt_size() - INIT_HEADER_SIZE)
+        } else {
+            data.len()
+        };
         frame[8..8 + count].copy_from_slice(&data[..count]);
         trace_hex(&frame);
 
@@ -116,10 +92,7 @@ impl U2FHIDInit {
 pub struct U2FHIDCont {}
 
 impl U2FHIDCont {
-    pub fn read<T>(dev: &mut T, seq: u8, max: usize) -> io::Result<Vec<u8>>
-    where
-        T: U2FDevice + io::Read,
-    {
+    pub fn read<T: HIDDevice>(dev: &mut T, seq: u8, max: usize) -> io::Result<Vec<u8>> {
         let mut frame = vec![0u8; dev.in_rpt_size()];
         let mut count = dev.read(&mut frame)?;
 
@@ -135,19 +108,24 @@ impl U2FHIDCont {
             return Err(io_err("invalid sequence number"));
         }
 
-        let max = cmp::min(max, dev.in_cont_data_size());
+        let max = if dev.in_rpt_size() >= CONT_HEADER_SIZE {
+            cmp::min(max, dev.in_rpt_size() - CONT_HEADER_SIZE)
+        } else {
+            max
+        };
         Ok(frame[5..5 + max].to_vec())
     }
 
-    pub fn write<T>(dev: &mut T, seq: u8, data: &[u8]) -> io::Result<usize>
-    where
-        T: U2FDevice + io::Write,
-    {
+    pub fn write<T: HIDDevice>(dev: &mut T, seq: u8, data: &[u8]) -> io::Result<usize> {
         let mut frame = vec![0u8; dev.out_rpt_size() + 1];
         frame[1..5].copy_from_slice(dev.get_cid());
         frame[5] = seq;
 
-        let count = cmp::min(data.len(), dev.out_cont_data_size());
+        let count = if dev.out_rpt_size() >= CONT_HEADER_SIZE {
+            cmp::min(data.len(), dev.out_rpt_size() - CONT_HEADER_SIZE)
+        } else {
+            data.len()
+        };
         frame[6..6 + count].copy_from_slice(&data[..count]);
         trace_hex(&frame);
 


### PR DESCRIPTION
We previously had
```rust
pub trait FidoDevice: HIDDevice
```
and
```rust
pub trait HIDDevice: U2FDevice
```
which made it difficult to implement virtual FIDO devices. This PR removes `U2FDevice` entirely and makes `HIDDevice` an extension of `FidoDevice`.

There are no functional changes.