### PR TITLE
Allow long CTAPHID_INIT responses

### DIFF
--- a/src/u2fprotocol.rs
+++ b/src/u2fprotocol.rs
@@ -244,10 +244,11 @@ pub(crate) mod tests {
 
         // init_resp packet
         let mut msg = CID_BROADCAST.to_vec();
-        msg.extend(vec![HIDCmd::Init.into(), 0x00, 0x11]); // cmd + bcnt
+        msg.extend(vec![HIDCmd::Init.into(), 0x00, 0x12]); // cmd + bcnt
         msg.extend_from_slice(&nonce);
         msg.extend_from_slice(&cid); // new channel id
         msg.extend(vec![0x02, 0x04, 0x01, 0x08, 0x01]); // versions + flags
+        msg.extend(vec![0xff]); // grease for future extension
         device.add_read(&msg, 0);
 
         init_device(&mut device, &nonce).unwrap();

--- a/src/u2ftypes.rs
+++ b/src/u2ftypes.rs
@@ -156,7 +156,7 @@ impl U2FHIDInitResp {
     pub fn read(data: &[u8], nonce: &[u8]) -> io::Result<U2FHIDInitResp> {
         assert_eq!(nonce.len(), INIT_NONCE_SIZE);
 
-        if data.len() != INIT_NONCE_SIZE + 9 {
+        if data.len() < INIT_NONCE_SIZE + 9 {
             return Err(io_err("invalid init response"));
         }
 


### PR DESCRIPTION
[CTAPHID_INIT](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#usb-hid-init): "A CTAPHID host SHALL accept a response size that is longer than the anticipated size to allow for future extensions of the protocol, yet maintaining backwards compatibility. Future versions will maintain the response structure of the current version, but additional fields may be added."