### PR TITLE
Remove StatusUpdates that include a U2FDeviceInfo

### DIFF
--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -87,20 +87,8 @@ fn main() {
             Ok(StatusUpdate::InteractiveManagement(..)) => {
                 panic!("STATUS: This can't happen when doing non-interactive usage");
             }
-            Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {dev_info}")
-            }
-            Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {dev_info}")
-            }
-            Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {dev_info}");
-            }
             Ok(StatusUpdate::SelectDeviceNotice) => {
                 println!("STATUS: Please select a device by touching one of them.");
-            }
-            Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {dev_info}");
             }
             Ok(StatusUpdate::PresenceRequired) => {
                 println!("STATUS: waiting for user presence");

--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -50,20 +50,8 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
             Ok(StatusUpdate::InteractiveManagement(..)) => {
                 panic!("STATUS: This can't happen when doing non-interactive usage");
             }
-            Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {dev_info}")
-            }
-            Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {dev_info}")
-            }
-            Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {dev_info}");
-            }
             Ok(StatusUpdate::SelectDeviceNotice) => {
                 println!("STATUS: Please select a device by touching one of them.");
-            }
-            Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {dev_info}");
             }
             Ok(StatusUpdate::PresenceRequired) => {
                 println!("STATUS: waiting for user presence");
@@ -246,20 +234,8 @@ fn main() {
             Ok(StatusUpdate::InteractiveManagement(..)) => {
                 panic!("STATUS: This can't happen when doing non-interactive usage");
             }
-            Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {dev_info}")
-            }
-            Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {dev_info}")
-            }
-            Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {dev_info}");
-            }
             Ok(StatusUpdate::SelectDeviceNotice) => {
                 println!("STATUS: Please select a device by touching one of them.");
-            }
-            Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {dev_info}");
             }
             Ok(StatusUpdate::PresenceRequired) => {
                 println!("STATUS: waiting for user presence");

--- a/examples/interactive_management.rs
+++ b/examples/interactive_management.rs
@@ -20,15 +20,10 @@ fn print_usage(program: &str, opts: Options) {
 }
 
 fn interactive_status_callback(status_rx: Receiver<StatusUpdate>) {
-    let mut num_of_devices = 0;
     loop {
         match status_rx.recv() {
-            Ok(StatusUpdate::InteractiveManagement((tx, dev_info, auth_info))) => {
-                debug!(
-                    "STATUS: interactive management: {:#}, {:#?}",
-                    dev_info, auth_info
-                );
-                println!("Device info {:#}", dev_info);
+            Ok(StatusUpdate::InteractiveManagement((tx, auth_info))) => {
+                debug!("STATUS: interactive management: {:#?}", auth_info);
                 let mut change_pin = false;
                 if let Some(info) = auth_info {
                     println!("Authenticator Info {:#?}", info);
@@ -98,27 +93,9 @@ fn interactive_status_callback(status_rx: Receiver<StatusUpdate>) {
                     println!("Device only supports CTAP1 and can't be managed.");
                 }
             }
-            Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                num_of_devices += 1;
-                debug!(
-                    "STATUS: New device #{} available: {}",
-                    num_of_devices, dev_info
-                );
-            }
-            Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                num_of_devices -= 1;
-                if num_of_devices <= 0 {
-                    println!("No more devices left. Please plug in a device!");
-                }
-                debug!("STATUS: Device became unavailable: {}", dev_info)
-            }
-            Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {}", dev_info);
-            }
             Ok(StatusUpdate::SelectDeviceNotice) => {
                 println!("STATUS: Please select a device by touching one of them.");
             }
-            Ok(StatusUpdate::DeviceSelected(_dev_info)) => {}
             Ok(StatusUpdate::PresenceRequired) => {
                 println!("STATUS: waiting for user presence");
             }

--- a/examples/reset.rs
+++ b/examples/reset.rs
@@ -105,9 +105,6 @@ fn main() {
                 manager.cancel().unwrap();
                 return;
             }
-            Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {dev_info}");
-            }
             Ok(StatusUpdate::PresenceRequired) => {
                 println!("STATUS: waiting for user presence");
                 break;

--- a/examples/set_pin.rs
+++ b/examples/set_pin.rs
@@ -73,20 +73,8 @@ fn main() {
             Ok(StatusUpdate::InteractiveManagement(..)) => {
                 panic!("STATUS: This can't happen when doing non-interactive usage");
             }
-            Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {dev_info}")
-            }
-            Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {dev_info}")
-            }
-            Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {dev_info}");
-            }
             Ok(StatusUpdate::SelectDeviceNotice) => {
                 println!("STATUS: Please select a device by touching one of them.");
-            }
-            Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {dev_info}");
             }
             Ok(StatusUpdate::PresenceRequired) => {
                 println!("STATUS: waiting for user presence");

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -80,20 +80,8 @@ fn main() {
             Ok(StatusUpdate::InteractiveManagement(..)) => {
                 panic!("STATUS: This can't happen when doing non-interactive usage");
             }
-            Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {dev_info}")
-            }
-            Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {dev_info}")
-            }
-            Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {dev_info}");
-            }
             Ok(StatusUpdate::SelectDeviceNotice) => {
                 println!("STATUS: Please select a device by touching one of them.");
-            }
-            Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {dev_info}");
             }
             Ok(StatusUpdate::PresenceRequired) => {
                 println!("STATUS: waiting for user presence");

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -424,12 +424,6 @@ pub fn register<Dev: FidoDevice>(
         let resp = dev.send_msg_cancellable(&makecred, alive);
         match resp {
             Ok(MakeCredentialsResult(attestation)) => {
-                send_status(
-                    &status,
-                    crate::StatusUpdate::Success {
-                        dev_info: dev.get_device_info(),
-                    },
-                );
                 callback.call(Ok(RegisterResult::CTAP2(attestation)));
                 return true;
             }
@@ -625,12 +619,6 @@ pub fn sign<Dev: FidoDevice>(
         }
         match resp {
             Ok(assertions) => {
-                send_status(
-                    &status,
-                    crate::StatusUpdate::Success {
-                        dev_info: dev.get_device_info(),
-                    },
-                );
                 callback.call(Ok(SignResult::CTAP2(assertions)));
                 return true;
             }
@@ -696,12 +684,6 @@ pub fn reset_helper(
     send_status(&status, crate::StatusUpdate::PresenceRequired);
     let resp = dev.send_cbor_cancellable(&reset, keep_alive);
     if resp.is_ok() {
-        send_status(
-            &status,
-            crate::StatusUpdate::Success {
-                dev_info: dev.get_device_info(),
-            },
-        );
         // The DeviceSelector could already be dead, but it might also wait
         // for us to respond, in order to cancel all other tokens in case
         // we skipped the "blinking"-action and went straight for the actual

--- a/src/status_update.rs
+++ b/src/status_update.rs
@@ -1,4 +1,4 @@
-use super::{u2ftypes, Pin};
+use super::Pin;
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use serde::{Deserialize, Serialize as DeriveSer, Serializer};
 use std::sync::mpsc::Sender;
@@ -55,27 +55,17 @@ pub enum StatusPinUv {
 
 #[derive(Debug)]
 pub enum StatusUpdate {
-    /// Device found
-    DeviceAvailable { dev_info: u2ftypes::U2FDeviceInfo },
-    /// Device got removed
-    DeviceUnavailable { dev_info: u2ftypes::U2FDeviceInfo },
     /// We're waiting for the user to touch their token
     PresenceRequired,
-    /// We successfully finished the register or sign request
-    Success { dev_info: u2ftypes::U2FDeviceInfo },
     /// Sent if a PIN is needed (or was wrong), or some other kind of PIN-related
     /// error occurred. The Sender is for sending back a PIN (if needed).
     PinUvError(StatusPinUv),
     /// Sent, if multiple devices are found and the user has to select one
     SelectDeviceNotice,
-    /// Sent, once a device was selected (either automatically or by user-interaction)
-    /// and the register or signing process continues with this device
-    DeviceSelected(u2ftypes::U2FDeviceInfo),
     /// Sent when a token was selected for interactive management
     InteractiveManagement(
         (
             Sender<InteractiveRequest>,
-            u2ftypes::U2FDeviceInfo,
             Option<AuthenticatorInfo>,
         ),
     ),

--- a/src/transport/freebsd/device.rs
+++ b/src/transport/freebsd/device.rs
@@ -4,7 +4,7 @@
 
 extern crate libc;
 
-use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
+use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::uhid;
@@ -169,6 +169,16 @@ impl HIDDevice for Device {
     fn get_property(&self, _prop_name: &str) -> io::Result<String> {
         Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
     }
+
+    fn get_device_info(&self) -> U2FDeviceInfo {
+        // unwrap is okay, as dev_info must have already been set, else
+        // a programmer error
+        self.dev_info.clone().unwrap()
+    }
+
+    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
+        self.dev_info = Some(dev_info);
+    }
 }
 
 impl FidoDevice for Device {
@@ -185,14 +195,10 @@ impl FidoDevice for Device {
         HIDDevice::sendrecv(self, cmd, send, keep_alive)
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
-    }
-
-    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
-        self.dev_info = Some(dev_info);
+    fn should_try_ctap2(&self) -> bool {
+        HIDDevice::get_device_info(self)
+            .cap_flags
+            .contains(Capability::CBOR)
     }
 
     fn initialized(&self) -> bool {

--- a/src/transport/hid.rs
+++ b/src/transport/hid.rs
@@ -18,6 +18,9 @@ pub trait HIDDevice: FidoDevice + Read + Write {
     fn new(parameters: Self::BuildParameters) -> Result<Self, (HIDError, Self::Id)>;
     fn id(&self) -> Self::Id;
 
+    fn get_device_info(&self) -> U2FDeviceInfo;
+    fn set_device_info(&mut self, dev_info: U2FDeviceInfo);
+
     // Channel ID management
     fn get_cid(&self) -> &[u8; 4];
     fn set_cid(&mut self, cid: [u8; 4]);

--- a/src/transport/linux/device.rs
+++ b/src/transport/linux/device.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate libc;
-use crate::consts::CID_BROADCAST;
+use crate::consts::{Capability, CID_BROADCAST};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::{hidraw, monitor};
@@ -121,6 +121,16 @@ impl HIDDevice for Device {
     fn get_property(&self, prop_name: &str) -> io::Result<String> {
         monitor::get_property_linux(&self.path, prop_name)
     }
+
+    fn get_device_info(&self) -> U2FDeviceInfo {
+        // unwrap is okay, as dev_info must have already been set, else
+        // a programmer error
+        self.dev_info.clone().unwrap()
+    }
+
+    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
+        self.dev_info = Some(dev_info);
+    }
 }
 
 impl FidoDevice for Device {
@@ -137,14 +147,10 @@ impl FidoDevice for Device {
         HIDDevice::sendrecv(self, cmd, send, keep_alive)
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
-    }
-
-    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
-        self.dev_info = Some(dev_info);
+    fn should_try_ctap2(&self) -> bool {
+        HIDDevice::get_device_info(self)
+            .cap_flags
+            .contains(Capability::CBOR)
     }
 
     fn initialized(&self) -> bool {

--- a/src/transport/netbsd/device.rs
+++ b/src/transport/netbsd/device.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate libc;
-use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
+use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::fd::Fd;
@@ -171,6 +171,16 @@ impl HIDDevice for Device {
     fn get_property(&self, _prop_name: &str) -> io::Result<String> {
         Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
     }
+
+    fn get_device_info(&self) -> U2FDeviceInfo {
+        // unwrap is okay, as dev_info must have already been set, else
+        // a programmer error
+        self.dev_info.clone().unwrap()
+    }
+
+    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
+        self.dev_info = Some(dev_info);
+    }
 }
 
 impl FidoDevice for Device {
@@ -187,14 +197,10 @@ impl FidoDevice for Device {
         HIDDevice::sendrecv(self, cmd, send, keep_alive)
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
-    }
-
-    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
-        self.dev_info = Some(dev_info);
+    fn should_try_ctap2(&self) -> bool {
+        HIDDevice::get_device_info(self)
+            .cap_flags
+            .contains(Capability::CBOR)
     }
 
     fn initialized(&self) -> bool {

--- a/src/transport/openbsd/device.rs
+++ b/src/transport/openbsd/device.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate libc;
-use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
+use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::monitor::WrappedOpenDevice;
@@ -152,6 +152,16 @@ impl HIDDevice for Device {
     fn get_property(&self, _prop_name: &str) -> io::Result<String> {
         Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
     }
+
+    fn get_device_info(&self) -> U2FDeviceInfo {
+        // unwrap is okay, as dev_info must have already been set, else
+        // a programmer error
+        self.dev_info.clone().unwrap()
+    }
+
+    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
+        self.dev_info = Some(dev_info);
+    }
 }
 
 impl FidoDevice for Device {
@@ -168,14 +178,10 @@ impl FidoDevice for Device {
         HIDDevice::sendrecv(self, cmd, send, keep_alive)
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
-    }
-
-    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
-        self.dev_info = Some(dev_info);
+    fn should_try_ctap2(&self) -> bool {
+        HIDDevice::get_device_info(self)
+            .cap_flags
+            .contains(Capability::CBOR)
     }
 
     fn initialized(&self) -> bool {

--- a/src/transport/stub/device.rs
+++ b/src/transport/stub/device.rs
@@ -62,6 +62,14 @@ impl HIDDevice for Device {
     fn get_property(&self, prop_name: &str) -> io::Result<String> {
         unimplemented!();
     }
+
+    fn get_device_info(&self) -> U2FDeviceInfo {
+        unimplemented!();
+    }
+
+    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
+        unimplemented!();
+    }
 }
 
 impl FidoDevice for Device {
@@ -78,20 +86,16 @@ impl FidoDevice for Device {
         unimplemented!();
     }
 
+    fn should_try_ctap2(&self) -> bool {
+        unimplemented!();
+    }
+
     fn initialized(&self) -> bool {
         unimplemented!();
     }
 
     fn is_u2f(&mut self) -> bool {
         unimplemented!()
-    }
-
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        unimplemented!();
-    }
-
-    fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
-        unimplemented!();
     }
 
     fn get_authenticator_info(&self) -> Option<&AuthenticatorInfo> {

--- a/src/u2fprotocol.rs
+++ b/src/u2fprotocol.rs
@@ -223,7 +223,6 @@ pub(crate) mod tests {
     use crate::consts::{Capability, HIDCmd, CID_BROADCAST, SW_NO_ERROR};
     use crate::transport::device_selector::Device;
     use crate::transport::hid::HIDDevice;
-    use crate::transport::FidoDevice;
     use crate::u2ftypes::U2FDeviceInfo;
     use rand::{thread_rng, RngCore};
 


### PR DESCRIPTION
(This is conceptually part of #270, but I separated it out since it has side effects.)

The abstract FidoDevice trait depends on `U2FDeviceInfo` through
```rust
fn get_device_info(&self) -> U2FDeviceInfo;
fn set_device_info(&mut self, dev_info: U2FDeviceInfo);
```
The data in `U2FDeviceInfo` is specific to the HID transport, and it's somewhat awkward to include it in virtual devices.

Apart from checking for the CBOR capability in `FidoDevice::init` (which is probably not necessary), we only use `get_device_info` in status updates. Firefox [doesn't do anything](https://searchfox.org/mozilla-central/source/dom/webauthn/authrs_bridge/src/lib.rs#296-304,311-313,363) with these status updates, so I don't see any reason to keep them.