### PR TITLE
Add `FidoDevice::get_protocol` and `FidoDevice::downgrade_to_ctap1`

### DIFF
--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -603,7 +603,7 @@ pub mod test {
     };
     use crate::transport::device_selector::Device;
     use crate::transport::hid::HIDDevice;
-    use crate::transport::FidoDevice;
+    use crate::transport::{FidoDevice, FidoProtocol};
     use crate::u2ftypes::U2FDeviceInfo;
     use rand::{thread_rng, RngCore};
 
@@ -642,6 +642,7 @@ pub mod test {
             None,
         );
         let mut device = Device::new("commands/get_assertion").unwrap();
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
         let mut cid = [0u8; 4];
         thread_rng().fill_bytes(&mut cid);
         device.set_cid(cid);
@@ -844,6 +845,8 @@ pub mod test {
         );
         let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
                                                                          // channel id
+        device.downgrade_to_ctap1();
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP1);
         let mut cid = [0u8; 4];
         thread_rng().fill_bytes(&mut cid);
 
@@ -935,6 +938,8 @@ pub mod test {
 
         let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
                                                                          // channel id
+        device.downgrade_to_ctap1();
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP1);
         let mut cid = [0u8; 4];
         thread_rng().fill_bytes(&mut cid);
 
@@ -1114,6 +1119,7 @@ pub mod test {
             None,
         );
         let mut device = Device::new("commands/get_assertion").unwrap();
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
         let mut cid = [0u8; 4];
         thread_rng().fill_bytes(&mut cid);
         device.set_cid(cid);

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -536,7 +536,7 @@ pub mod tests {
     use crate::crypto::COSEAlgorithm;
     use crate::transport::device_selector::Device;
     use crate::transport::platform::device::IN_HID_RPT_SIZE;
-    use crate::transport::{hid::HIDDevice, FidoDevice, Nonce};
+    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol, Nonce};
     use rand::{thread_rng, RngCore};
     use serde_cbor::de::from_slice;
 
@@ -854,6 +854,7 @@ pub mod tests {
     #[test]
     fn test_get_info_ctap2_only() {
         let mut device = Device::new("commands/get_info").unwrap();
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
         let nonce = [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01];
 
         // channel id

--- a/src/ctap2/commands/get_version.rs
+++ b/src/ctap2/commands/get_version.rs
@@ -50,12 +50,14 @@ impl RequestCtap1 for GetVersion {
 pub mod tests {
     use crate::consts::{Capability, HIDCmd, CID_BROADCAST, SW_NO_ERROR};
     use crate::transport::device_selector::Device;
-    use crate::transport::{hid::HIDDevice, FidoDevice, Nonce};
+    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol, Nonce};
     use rand::{thread_rng, RngCore};
 
     #[test]
     fn test_get_version_ctap1_only() {
         let mut device = Device::new("commands/get_version").unwrap();
+        device.downgrade_to_ctap1();
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP1);
         let nonce = [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01];
 
         // channel id

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -460,6 +460,7 @@ pub mod test {
     };
     use crate::transport::device_selector::Device;
     use crate::transport::hid::HIDDevice;
+    use crate::transport::{FidoDevice, FidoProtocol};
     use serde_bytes::ByteBuf;
 
     fn create_attestation_obj() -> AttestationObject {
@@ -595,6 +596,7 @@ pub mod test {
         );
 
         let mut device = Device::new("commands/make_credentials").unwrap(); // not really used (all functions ignore it)
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
         let req_serialized = req
             .wire_format()
             .expect("Failed to serialize MakeCredentials request");

--- a/src/ctap2/commands/reset.rs
+++ b/src/ctap2/commands/reset.rs
@@ -47,12 +47,13 @@ pub mod tests {
     use super::*;
     use crate::consts::HIDCmd;
     use crate::transport::device_selector::Device;
-    use crate::transport::{hid::HIDDevice, FidoDevice};
+    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
     use rand::{thread_rng, RngCore};
     use serde_cbor::{de::from_slice, Value};
 
     fn issue_command_and_get_response(cmd: u8, add: &[u8]) -> Result<(), HIDError> {
         let mut device = Device::new("commands/Reset").unwrap();
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
         // ctap2 request
         let mut cid = [0u8; 4];
         thread_rng().fill_bytes(&mut cid);

--- a/src/ctap2/commands/selection.rs
+++ b/src/ctap2/commands/selection.rs
@@ -47,12 +47,13 @@ pub mod tests {
     use super::*;
     use crate::consts::HIDCmd;
     use crate::transport::device_selector::Device;
-    use crate::transport::{hid::HIDDevice, FidoDevice};
+    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
     use rand::{thread_rng, RngCore};
     use serde_cbor::{de::from_slice, Value};
 
     fn issue_command_and_get_response(cmd: u8, add: &[u8]) -> Result<(), HIDError> {
         let mut device = Device::new("commands/selection").unwrap();
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
         // ctap2 request
         let mut cid = [0u8; 4];
         thread_rng().fill_bytes(&mut cid);

--- a/src/transport/freebsd/device.rs
+++ b/src/transport/freebsd/device.rs
@@ -8,7 +8,7 @@ use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::uhid;
-use crate::transport::{FidoDevice, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::from_unix_result;
 use crate::util::io_err;
@@ -26,6 +26,7 @@ pub struct Device {
     dev_info: Option<U2FDeviceInfo>,
     secret: Option<SharedSecret>,
     authenticator_info: Option<AuthenticatorInfo>,
+    protocol: FidoProtocol,
 }
 
 impl Device {
@@ -137,6 +138,7 @@ impl HIDDevice for Device {
             dev_info: None,
             secret: None,
             authenticator_info: None,
+            protocol: FidoProtocol::CTAP2,
         };
         if res.is_u2f() {
             info!("new device {:?}", res.path);
@@ -230,5 +232,13 @@ impl FidoDevice for Device {
 
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
+    }
+
+    fn get_protocol(&self) -> FidoProtocol {
+        self.protocol
+    }
+
+    fn downgrade_to_ctap1(&mut self) {
+        self.protocol = FidoProtocol::CTAP1;
     }
 }

--- a/src/transport/hid.rs
+++ b/src/transport/hid.rs
@@ -1,7 +1,7 @@
 use crate::consts::{HIDCmd, CID_BROADCAST};
 
-use crate::transport::FidoDevice;
 use crate::transport::{errors::HIDError, Nonce};
+use crate::transport::{FidoDevice, FidoProtocol};
 use crate::u2ftypes::{U2FDeviceInfo, U2FHIDCont, U2FHIDInit, U2FHIDInitResp};
 use rand::{thread_rng, RngCore};
 use std::cmp::Eq;
@@ -114,7 +114,7 @@ pub trait HIDDevice: FidoDevice + Read + Write {
 
         // If this is a CTAP2 device we can tell the authenticator to cancel the transaction on its
         // side as well. There's nothing to do for U2F/CTAP1 devices.
-        if self.get_authenticator_info().is_some() {
+        if self.get_protocol() == FidoProtocol::CTAP2 {
             self.u2f_write(u8::from(HIDCmd::Cancel), &[])?;
         }
         // For CTAP2 devices we expect to read

--- a/src/transport/linux/device.rs
+++ b/src/transport/linux/device.rs
@@ -7,7 +7,7 @@ use crate::consts::{Capability, CID_BROADCAST};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::{hidraw, monitor};
-use crate::transport::{FidoDevice, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::from_unix_result;
 use std::fs::OpenOptions;
@@ -27,6 +27,7 @@ pub struct Device {
     dev_info: Option<U2FDeviceInfo>,
     secret: Option<SharedSecret>,
     authenticator_info: Option<AuthenticatorInfo>,
+    protocol: FidoProtocol,
 }
 
 impl PartialEq for Device {
@@ -89,6 +90,7 @@ impl HIDDevice for Device {
             dev_info: None,
             secret: None,
             authenticator_info: None,
+            protocol: FidoProtocol::CTAP2,
         };
         if res.is_u2f() {
             info!("new device {:?}", res.path);
@@ -176,5 +178,13 @@ impl FidoDevice for Device {
 
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
+    }
+
+    fn get_protocol(&self) -> FidoProtocol {
+        self.protocol
+    }
+
+    fn downgrade_to_ctap1(&mut self) {
+        self.protocol = FidoProtocol::CTAP1;
     }
 }

--- a/src/transport/macos/device.rs
+++ b/src/transport/macos/device.rs
@@ -8,7 +8,7 @@ use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::iokit::*;
-use crate::transport::{FidoDevice, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use core_foundation::base::*;
 use core_foundation::string::*;
@@ -29,6 +29,7 @@ pub struct Device {
     dev_info: Option<U2FDeviceInfo>,
     secret: Option<SharedSecret>,
     authenticator_info: Option<AuthenticatorInfo>,
+    protocol: FidoProtocol,
 }
 
 impl Device {
@@ -143,6 +144,7 @@ impl HIDDevice for Device {
             dev_info: None,
             secret: None,
             authenticator_info: None,
+            protocol: FidoProtocol::CTAP2,
         })
     }
 
@@ -221,5 +223,13 @@ impl FidoDevice for Device {
 
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
+    }
+
+    fn get_protocol(&self) -> FidoProtocol {
+        self.protocol
+    }
+
+    fn downgrade_to_ctap1(&mut self) {
+        self.protocol = FidoProtocol::CTAP1;
     }
 }

--- a/src/transport/mock/device.rs
+++ b/src/transport/mock/device.rs
@@ -5,7 +5,7 @@ use crate::consts::{Capability, HIDCmd, CID_BROADCAST};
 use crate::crypto::SharedSecret;
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::device_selector::DeviceCommand;
-use crate::transport::{hid::HIDDevice, FidoDevice, HIDError, Nonce};
+use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol, HIDError, Nonce};
 use crate::u2ftypes::U2FDeviceInfo;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Read, Write};
@@ -24,6 +24,7 @@ pub struct Device {
     pub authenticator_info: Option<AuthenticatorInfo>,
     pub sender: Option<Sender<DeviceCommand>>,
     pub receiver: Option<Receiver<DeviceCommand>>,
+    pub protocol: FidoProtocol,
 }
 
 impl Device {
@@ -122,6 +123,7 @@ impl HIDDevice for Device {
             authenticator_info: None,
             sender: None,
             receiver: None,
+            protocol: FidoProtocol::CTAP2,
         })
     }
 
@@ -196,5 +198,13 @@ impl FidoDevice for Device {
 
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
+    }
+
+    fn get_protocol(&self) -> FidoProtocol {
+        self.protocol
+    }
+
+    fn downgrade_to_ctap1(&mut self) {
+        self.protocol = FidoProtocol::CTAP1;
     }
 }

--- a/src/transport/netbsd/device.rs
+++ b/src/transport/netbsd/device.rs
@@ -9,7 +9,7 @@ use crate::transport::hid::HIDDevice;
 use crate::transport::platform::fd::Fd;
 use crate::transport::platform::monitor::WrappedOpenDevice;
 use crate::transport::platform::uhid;
-use crate::transport::{FidoDevice, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::io_err;
 use std::ffi::OsString;
@@ -25,6 +25,7 @@ pub struct Device {
     dev_info: Option<U2FDeviceInfo>,
     secret: Option<SharedSecret>,
     authenticator_info: Option<AuthenticatorInfo>,
+    protocol: FidoProtocol,
 }
 
 impl Device {
@@ -139,6 +140,7 @@ impl HIDDevice for Device {
             dev_info: None,
             secret: None,
             authenticator_info: None,
+            protocol: FidoProtocol::CTAP2,
         };
         if res.is_u2f() {
             info!("new device {:?}", res.path);
@@ -243,5 +245,13 @@ impl FidoDevice for Device {
 
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
+    }
+
+    fn get_protocol(&self) -> FidoProtocol {
+        self.protocol
+    }
+
+    fn downgrade_to_ctap1(&mut self) {
+        self.protocol = FidoProtocol::CTAP1;
     }
 }

--- a/src/transport/openbsd/device.rs
+++ b/src/transport/openbsd/device.rs
@@ -7,7 +7,7 @@ use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::monitor::WrappedOpenDevice;
-use crate::transport::{FidoDevice, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::{from_unix_result, io_err};
 use std::ffi::{CString, OsString};
@@ -26,6 +26,7 @@ pub struct Device {
     dev_info: Option<U2FDeviceInfo>,
     secret: Option<SharedSecret>,
     authenticator_info: Option<AuthenticatorInfo>,
+    protocol: FidoProtocol,
 }
 
 impl Device {
@@ -120,6 +121,7 @@ impl HIDDevice for Device {
             dev_info: None,
             secret: None,
             authenticator_info: None,
+            protocol: FidoProtocol::CTAP2,
         };
         if res.is_u2f() {
             info!("new device {:?}", res.path);
@@ -219,5 +221,13 @@ impl FidoDevice for Device {
 
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
+    }
+
+    fn get_protocol(&self) -> FidoProtocol {
+        self.protocol
+    }
+
+    fn downgrade_to_ctap1(&mut self) {
+        self.protocol = FidoProtocol::CTAP1;
     }
 }

--- a/src/transport/stub/device.rs
+++ b/src/transport/stub/device.rs
@@ -4,8 +4,8 @@
 
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
-use crate::transport::FidoDevice;
-use crate::transport::{HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDCmd};
+use crate::transport::{HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use std::hash::Hash;
 use std::io;
@@ -111,6 +111,14 @@ impl FidoDevice for Device {
     }
 
     fn get_shared_secret(&self) -> Option<&SharedSecret> {
+        unimplemented!()
+    }
+
+    fn get_protocol(&self) -> FidoProtocol {
+        unimplemented!()
+    }
+
+    fn downgrade_to_ctap1(&mut self) {
         unimplemented!()
     }
 }

--- a/src/transport/windows/device.rs
+++ b/src/transport/windows/device.rs
@@ -8,7 +8,7 @@ use crate::consts::{
 };
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
-use crate::transport::{FidoDevice, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};
@@ -23,6 +23,7 @@ pub struct Device {
     dev_info: Option<U2FDeviceInfo>,
     secret: Option<SharedSecret>,
     authenticator_info: Option<AuthenticatorInfo>,
+    protocol: FidoProtocol,
 }
 
 impl PartialEq for Device {
@@ -79,6 +80,7 @@ impl HIDDevice for Device {
             dev_info: None,
             secret: None,
             authenticator_info: None,
+            protocol: FidoProtocol::CTAP2,
         };
         if res.is_u2f() {
             info!("new device {:?}", res.path);
@@ -168,5 +170,13 @@ impl FidoDevice for Device {
 
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo) {
         self.authenticator_info = Some(authenticator_info);
+    }
+
+    fn get_protocol(&self) -> FidoProtocol {
+        self.protocol
+    }
+
+    fn downgrade_to_ctap1(&mut self) {
+        self.protocol = FidoProtocol::CTAP1;
     }
 }


### PR DESCRIPTION
This is a prerequisite for #269. We need a way to downgrade CTAP2 capable devices to CTAP1.