### PR TITLE
Add `VirtualFidoDevice` trait and `send_to_virtual_device` functions

### DIFF
--- a/src/ctap2/commands/client_pin.rs
+++ b/src/ctap2/commands/client_pin.rs
@@ -5,7 +5,7 @@
 use super::{get_info::AuthenticatorInfo, Command, CommandError, RequestCtap2, StatusCode};
 use crate::crypto::{COSEKey, CryptoError, PinUvAuthProtocol, PinUvAuthToken, SharedSecret};
 use crate::transport::errors::HIDError;
-use crate::transport::FidoDevice;
+use crate::transport::{FidoDevice, VirtualFidoDevice};
 use serde::{
     de::{Error as SerdeError, IgnoredAny, MapAccess, Visitor},
     ser::SerializeMap,
@@ -649,6 +649,13 @@ where
             };
             Err(CommandError::StatusCode(status, add_data).into())
         }
+    }
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError> {
+        dev.client_pin(self)
     }
 }
 

--- a/src/ctap2/commands/client_pin.rs
+++ b/src/ctap2/commands/client_pin.rs
@@ -3,7 +3,7 @@
 //       The current version of `bitflags` doesn't seem to allow
 //       to set this for an individual bitflag-struct.
 use super::{get_info::AuthenticatorInfo, Command, CommandError, RequestCtap2, StatusCode};
-use crate::crypto::{COSEKey, CryptoError, PinUvAuthProtocol, PinUvAuthToken, SharedSecret};
+use crate::crypto::{COSEKey, CryptoError, PinUvAuthProtocol, SharedSecret};
 use crate::transport::errors::HIDError;
 use crate::transport::{FidoDevice, VirtualFidoDevice};
 use serde::{
@@ -145,13 +145,14 @@ pub trait ClientPINSubCommand {
     fn parse_response_payload(&self, input: &[u8]) -> Result<Self::Output, CommandError>;
 }
 
-struct ClientPinResponse {
-    key_agreement: Option<COSEKey>,
-    pin_token: Option<EncryptedPinToken>,
+#[derive(Default)]
+pub struct ClientPinResponse {
+    pub key_agreement: Option<COSEKey>,
+    pub pin_token: Option<EncryptedPinToken>,
     /// Number of PIN attempts remaining before lockout.
-    pin_retries: Option<u8>,
-    power_cycle_state: Option<bool>,
-    uv_retries: Option<u8>,
+    pub pin_retries: Option<u8>,
+    pub power_cycle_state: Option<bool>,
+    pub uv_retries: Option<u8>,
 }
 
 impl<'de> Deserialize<'de> for ClientPinResponse {
@@ -241,7 +242,7 @@ impl GetKeyAgreement {
 }
 
 impl ClientPINSubCommand for GetKeyAgreement {
-    type Output = KeyAgreement;
+    type Output = ClientPinResponse;
 
     fn as_client_pin(&self) -> Result<ClientPIN, CommandError> {
         Ok(ClientPIN {
@@ -257,14 +258,10 @@ impl ClientPINSubCommand for GetKeyAgreement {
 
         let get_pin_response: ClientPinResponse =
             from_slice(input).map_err(CommandError::Deserializing)?;
-        if let Some(key_agreement) = get_pin_response.key_agreement {
-            Ok(KeyAgreement {
-                pin_protocol: self.pin_protocol.clone(),
-                peer_key: key_agreement,
-            })
-        } else {
-            Err(CommandError::MissingRequiredField("key_agreement"))
+        if get_pin_response.key_agreement.is_none() {
+            return Err(CommandError::MissingRequiredField("key_agreement"));
         }
+        Ok(get_pin_response)
     }
 }
 
@@ -283,7 +280,7 @@ impl<'sc, 'pin> GetPinToken<'sc, 'pin> {
 }
 
 impl<'sc, 'pin> ClientPINSubCommand for GetPinToken<'sc, 'pin> {
-    type Output = PinUvAuthToken;
+    type Output = ClientPinResponse;
 
     fn as_client_pin(&self) -> Result<ClientPIN, CommandError> {
         let input = self.pin.for_pin_token();
@@ -306,19 +303,10 @@ impl<'sc, 'pin> ClientPINSubCommand for GetPinToken<'sc, 'pin> {
 
         let get_pin_response: ClientPinResponse =
             from_slice(input).map_err(CommandError::Deserializing)?;
-        match get_pin_response.pin_token {
-            Some(encrypted_pin_token) => {
-                // CTAP 2.1 spec:
-                // If authenticatorClientPIN's getPinToken subcommand is invoked, default permissions
-                // of `mc` and `ga` (value 0x03) are granted for the returned pinUvAuthToken.
-                let default_permissions = PinUvAuthTokenPermission::default();
-                let pin_token = self
-                    .shared_secret
-                    .decrypt_pin_token(default_permissions, encrypted_pin_token.as_ref())?;
-                Ok(pin_token)
-            }
-            None => Err(CommandError::MissingRequiredField("key_agreement")),
+        if get_pin_response.pin_token.is_none() {
+            return Err(CommandError::MissingRequiredField("pin_token"));
         }
+        Ok(get_pin_response)
     }
 }
 
@@ -347,7 +335,7 @@ impl<'sc, 'pin> GetPinUvAuthTokenUsingPinWithPermissions<'sc, 'pin> {
 }
 
 impl<'sc, 'pin> ClientPINSubCommand for GetPinUvAuthTokenUsingPinWithPermissions<'sc, 'pin> {
-    type Output = PinUvAuthToken;
+    type Output = ClientPinResponse;
 
     fn as_client_pin(&self) -> Result<ClientPIN, CommandError> {
         let input = self.pin.for_pin_token();
@@ -374,15 +362,10 @@ impl<'sc, 'pin> ClientPINSubCommand for GetPinUvAuthTokenUsingPinWithPermissions
 
         let get_pin_response: ClientPinResponse =
             from_slice(input).map_err(CommandError::Deserializing)?;
-        match get_pin_response.pin_token {
-            Some(encrypted_pin_token) => {
-                let pin_token = self
-                    .shared_secret
-                    .decrypt_pin_token(self.permissions, encrypted_pin_token.as_ref())?;
-                Ok(pin_token)
-            }
-            None => Err(CommandError::MissingRequiredField("key_agreement")),
+        if get_pin_response.pin_token.is_none() {
+            return Err(CommandError::MissingRequiredField("pin_token"));
         }
+        Ok(get_pin_response)
     }
 }
 
@@ -398,7 +381,7 @@ macro_rules! implementRetries {
         }
 
         impl ClientPINSubCommand for $name {
-            type Output = u8;
+            type Output = ClientPinResponse;
 
             fn as_client_pin(&self) -> Result<ClientPIN, CommandError> {
                 Ok(ClientPIN {
@@ -413,10 +396,10 @@ macro_rules! implementRetries {
 
                 let get_pin_response: ClientPinResponse =
                     from_slice(input).map_err(CommandError::Deserializing)?;
-                match get_pin_response.$getter {
-                    Some($getter) => Ok($getter),
-                    None => Err(CommandError::MissingRequiredField(stringify!($getter))),
+                if get_pin_response.$getter.is_none() {
+                    return Err(CommandError::MissingRequiredField(stringify!($getter)));
                 }
+                Ok(get_pin_response)
             }
         }
     };
@@ -447,7 +430,7 @@ impl<'sc> GetPinUvAuthTokenUsingUvWithPermissions<'sc> {
 }
 
 impl<'sc> ClientPINSubCommand for GetPinUvAuthTokenUsingUvWithPermissions<'sc> {
-    type Output = PinUvAuthToken;
+    type Output = ClientPinResponse;
 
     fn as_client_pin(&self) -> Result<ClientPIN, CommandError> {
         Ok(ClientPIN {
@@ -467,15 +450,10 @@ impl<'sc> ClientPINSubCommand for GetPinUvAuthTokenUsingUvWithPermissions<'sc> {
 
         let get_pin_response: ClientPinResponse =
             from_slice(input).map_err(CommandError::Deserializing)?;
-        match get_pin_response.pin_token {
-            Some(encrypted_pin_token) => {
-                let pin_token = self
-                    .shared_secret
-                    .decrypt_pin_token(self.permissions, encrypted_pin_token.as_ref())?;
-                Ok(pin_token)
-            }
-            None => Err(CommandError::MissingRequiredField("key_agreement")),
+        if get_pin_response.pin_token.is_none() {
+            return Err(CommandError::MissingRequiredField("pin_token"));
         }
+        Ok(get_pin_response)
     }
 }
 
@@ -495,7 +473,7 @@ impl<'sc, 'pin> SetNewPin<'sc, 'pin> {
 }
 
 impl<'sc, 'pin> ClientPINSubCommand for SetNewPin<'sc, 'pin> {
-    type Output = ();
+    type Output = ClientPinResponse;
 
     fn as_client_pin(&self) -> Result<ClientPIN, CommandError> {
         if self.new_pin.as_bytes().len() > 63 {
@@ -526,12 +504,10 @@ impl<'sc, 'pin> ClientPINSubCommand for SetNewPin<'sc, 'pin> {
 
     fn parse_response_payload(&self, input: &[u8]) -> Result<Self::Output, CommandError> {
         // Should be an empty response or a valid cbor-value (which we ignore)
-        if input.is_empty() {
-            Ok(())
-        } else {
+        if !input.is_empty() {
             let _: Value = from_slice(input).map_err(CommandError::Deserializing)?;
-            Ok(())
         }
+        Ok(ClientPinResponse::default())
     }
 }
 
@@ -560,7 +536,7 @@ impl<'sc, 'pin> ChangeExistingPin<'sc, 'pin> {
 }
 
 impl<'sc, 'pin> ClientPINSubCommand for ChangeExistingPin<'sc, 'pin> {
-    type Output = ();
+    type Output = ClientPinResponse;
 
     fn as_client_pin(&self) -> Result<ClientPIN, CommandError> {
         if self.new_pin.as_bytes().len() > 63 {
@@ -597,18 +573,16 @@ impl<'sc, 'pin> ClientPINSubCommand for ChangeExistingPin<'sc, 'pin> {
 
     fn parse_response_payload(&self, input: &[u8]) -> Result<Self::Output, CommandError> {
         // Should be an empty response or a valid cbor-value (which we ignore)
-        if input.is_empty() {
-            Ok(())
-        } else {
+        if !input.is_empty() {
             let _: Value = from_slice(input).map_err(CommandError::Deserializing)?;
-            Ok(())
         }
+        Ok(ClientPinResponse::default())
     }
 }
 
 impl<T> RequestCtap2 for T
 where
-    T: ClientPINSubCommand,
+    T: ClientPINSubCommand<Output = ClientPinResponse>,
     T: fmt::Debug,
 {
     type Output = <T as ClientPINSubCommand>::Output;
@@ -654,20 +628,8 @@ where
     fn send_to_virtual_device<Dev: VirtualFidoDevice>(
         &self,
         dev: &mut Dev,
-    ) -> Result<Self::Output, HIDError> {
-        dev.client_pin(self)
-    }
-}
-
-#[derive(Debug)]
-pub struct KeyAgreement {
-    pin_protocol: PinUvAuthProtocol,
-    peer_key: COSEKey,
-}
-
-impl KeyAgreement {
-    pub fn shared_secret(&self) -> Result<SharedSecret, CommandError> {
-        Ok(self.pin_protocol.encapsulate(&self.peer_key)?)
+    ) -> Result<ClientPinResponse, HIDError> {
+        dev.client_pin(&self.as_client_pin()?)
     }
 }
 

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -603,7 +603,7 @@ pub mod test {
     };
     use crate::transport::device_selector::Device;
     use crate::transport::hid::HIDDevice;
-    use crate::transport::{FidoDevice, FidoProtocol};
+    use crate::transport::{FidoDevice, FidoDeviceIO, FidoProtocol};
     use crate::u2ftypes::U2FDeviceInfo;
     use rand::{thread_rng, RngCore};
 

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -19,7 +19,7 @@ use crate::ctap2::server::{
 use crate::ctap2::utils::{read_be_u32, read_byte};
 use crate::errors::AuthenticatorError;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
-use crate::transport::FidoDevice;
+use crate::transport::{FidoDevice, VirtualFidoDevice};
 use crate::u2ftypes::CTAP1RequestAPDU;
 use serde::{
     de::{Error as DesError, MapAccess, Visitor},
@@ -364,6 +364,13 @@ impl RequestCtap1 for GetAssertion {
             .map_err(HIDError::Command)
             .map_err(Retryable::Error)
     }
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError> {
+        dev.get_assertion(self)
+    }
 }
 
 impl RequestCtap2 for GetAssertion {
@@ -417,6 +424,13 @@ impl RequestCtap2 for GetAssertion {
         } else {
             Err(CommandError::StatusCode(status, None).into())
         }
+    }
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError> {
+        dev.get_assertion(self)
     }
 }
 

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -2,7 +2,7 @@ use super::{Command, CommandError, RequestCtap2, StatusCode};
 use crate::ctap2::attestation::AAGuid;
 use crate::ctap2::server::PublicKeyCredentialParameters;
 use crate::transport::errors::HIDError;
-use crate::transport::FidoDevice;
+use crate::transport::{FidoDevice, VirtualFidoDevice};
 use serde::{
     de::{Error as SError, IgnoredAny, MapAccess, Visitor},
     Deserialize, Deserializer, Serialize,
@@ -49,6 +49,13 @@ impl RequestCtap2 for GetInfo {
         } else {
             Err(CommandError::InputTooSmall.into())
         }
+    }
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError> {
+        dev.get_info()
     }
 }
 

--- a/src/ctap2/commands/get_next_assertion.rs
+++ b/src/ctap2/commands/get_next_assertion.rs
@@ -1,7 +1,7 @@
 use super::{Command, CommandError, RequestCtap2, StatusCode};
 use crate::ctap2::commands::get_assertion::GetAssertionResponse;
 use crate::transport::errors::HIDError;
-use crate::transport::FidoDevice;
+use crate::transport::{FidoDevice, VirtualFidoDevice};
 use serde_cbor::{de::from_slice, Value};
 
 #[derive(Debug)]
@@ -43,5 +43,12 @@ impl RequestCtap2 for GetNextAssertion {
         } else {
             Err(CommandError::StatusCode(status, None).into())
         }
+    }
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        _dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError> {
+        unimplemented!()
     }
 }

--- a/src/ctap2/commands/get_version.rs
+++ b/src/ctap2/commands/get_version.rs
@@ -1,6 +1,7 @@
 use super::{CommandError, RequestCtap1, Retryable};
 use crate::consts::U2F_VERSION;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
+use crate::transport::VirtualFidoDevice;
 use crate::u2ftypes::CTAP1RequestAPDU;
 
 #[allow(non_camel_case_types)]
@@ -43,6 +44,13 @@ impl RequestCtap1 for GetVersion {
         let cmd = U2F_VERSION;
         let data = CTAP1RequestAPDU::serialize(cmd, flags, &[])?;
         Ok((data, ()))
+    }
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError> {
+        dev.get_version(self)
     }
 }
 

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -21,7 +21,7 @@ use crate::ctap2::server::{
 use crate::ctap2::utils::{read_byte, serde_parse_err};
 use crate::errors::AuthenticatorError;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
-use crate::transport::FidoDevice;
+use crate::transport::{FidoDevice, VirtualFidoDevice};
 use crate::u2ftypes::CTAP1RequestAPDU;
 #[cfg(test)]
 use serde::Deserialize;
@@ -362,6 +362,13 @@ impl RequestCtap1 for MakeCredentials {
             .map_err(HIDError::Command)
             .map_err(Retryable::Error)
     }
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError> {
+        dev.make_credentials(self)
+    }
 }
 
 impl RequestCtap2 for MakeCredentials {
@@ -402,6 +409,13 @@ impl RequestCtap2 for MakeCredentials {
         } else {
             Err(HIDError::Command(CommandError::StatusCode(status, None)))
         }
+    }
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError> {
+        dev.make_credentials(self)
     }
 }
 

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -5,7 +5,7 @@ use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::ctap2::server::UserVerificationRequirement;
 use crate::errors::AuthenticatorError;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
-use crate::transport::FidoDevice;
+use crate::transport::{FidoDevice, VirtualFidoDevice};
 use serde_cbor::{error::Error as CborError, Value};
 use serde_json as json;
 use std::error::Error as StdErrorT;
@@ -70,6 +70,11 @@ pub trait RequestCtap1: fmt::Debug {
         input: &[u8],
         add_info: &Self::AdditionalInfo,
     ) -> Result<Self::Output, Retryable<HIDError>>;
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError>;
 }
 
 pub trait RequestCtap2: fmt::Debug {
@@ -83,6 +88,11 @@ pub trait RequestCtap2: fmt::Debug {
         &self,
         dev: &mut Dev,
         input: &[u8],
+    ) -> Result<Self::Output, HIDError>;
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
     ) -> Result<Self::Output, HIDError>;
 }
 

--- a/src/ctap2/commands/reset.rs
+++ b/src/ctap2/commands/reset.rs
@@ -1,6 +1,6 @@
 use super::{Command, CommandError, RequestCtap2, StatusCode};
 use crate::transport::errors::HIDError;
-use crate::transport::FidoDevice;
+use crate::transport::{FidoDevice, VirtualFidoDevice};
 use serde_cbor::{de::from_slice, Value};
 
 #[derive(Debug, Default)]
@@ -39,6 +39,13 @@ impl RequestCtap2 for Reset {
             };
             Err(CommandError::StatusCode(status, msg).into())
         }
+    }
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError> {
+        dev.reset(self)
     }
 }
 

--- a/src/ctap2/commands/reset.rs
+++ b/src/ctap2/commands/reset.rs
@@ -47,7 +47,7 @@ pub mod tests {
     use super::*;
     use crate::consts::HIDCmd;
     use crate::transport::device_selector::Device;
-    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
+    use crate::transport::{hid::HIDDevice, FidoDevice, FidoDeviceIO, FidoProtocol};
     use rand::{thread_rng, RngCore};
     use serde_cbor::{de::from_slice, Value};
 

--- a/src/ctap2/commands/selection.rs
+++ b/src/ctap2/commands/selection.rs
@@ -1,6 +1,6 @@
 use super::{Command, CommandError, RequestCtap2, StatusCode};
 use crate::transport::errors::HIDError;
-use crate::transport::FidoDevice;
+use crate::transport::{FidoDevice, VirtualFidoDevice};
 use serde_cbor::{de::from_slice, Value};
 
 #[derive(Debug, Default)]
@@ -39,6 +39,13 @@ impl RequestCtap2 for Selection {
             };
             Err(CommandError::StatusCode(status, msg).into())
         }
+    }
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError> {
+        dev.selection(self)
     }
 }
 

--- a/src/ctap2/commands/selection.rs
+++ b/src/ctap2/commands/selection.rs
@@ -47,7 +47,7 @@ pub mod tests {
     use super::*;
     use crate::consts::HIDCmd;
     use crate::transport::device_selector::Device;
-    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
+    use crate::transport::{hid::HIDDevice, FidoDevice, FidoDeviceIO, FidoProtocol};
     use rand::{thread_rng, RngCore};
     use serde_cbor::{de::from_slice, Value};
 

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -35,7 +35,7 @@ use crate::errors::{AuthenticatorError, UnsupportedOption};
 use crate::statecallback::StateCallback;
 use crate::transport::device_selector::{Device, DeviceSelectorEvent};
 
-use crate::transport::{errors::HIDError, hid::HIDDevice, FidoDevice, FidoProtocol};
+use crate::transport::{errors::HIDError, hid::HIDDevice, FidoDevice, FidoDeviceIO, FidoProtocol};
 
 use crate::{send_status, RegisterResult, SignResult, StatusPinUv, StatusUpdate};
 use std::sync::mpsc::{channel, RecvError, Sender};

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -803,6 +803,7 @@ pub fn set_or_change_pin_helper(
         dev.send_cbor_cancellable(&SetNewPin::new(&shared_secret, &new_pin), alive)
             .map_err(AuthenticatorError::HIDError)
     };
-
-    callback.call(res);
+    // the callback is expecting `Result<(), AuthenticatorError>`, but `ChangeExistingPin`
+    // and `SetNewPin` return the default `ClientPinResponse` on success. Just discard it.
+    callback.call(res.map(|_| ()));
 }

--- a/src/ctap2/preflight.rs
+++ b/src/ctap2/preflight.rs
@@ -7,7 +7,7 @@ use crate::crypto::PinUvAuthToken;
 use crate::ctap2::server::{PublicKeyCredentialDescriptor, RelyingPartyWrapper};
 use crate::errors::AuthenticatorError;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
-use crate::transport::FidoDevice;
+use crate::transport::{FidoDevice, VirtualFidoDevice};
 use crate::u2ftypes::CTAP1RequestAPDU;
 use sha2::{Digest, Sha256};
 
@@ -17,7 +17,7 @@ use sha2::{Digest, Sha256};
 /// should send to the token. Or before a MakeCredential command, to determine
 /// if this token is already registered or not.
 #[derive(Debug)]
-pub(crate) struct CheckKeyHandle<'assertion> {
+pub struct CheckKeyHandle<'assertion> {
     pub(crate) key_handle: &'assertion [u8],
     pub(crate) client_data_hash: &'assertion [u8],
     pub(crate) rp: &'assertion RelyingPartyWrapper,
@@ -64,6 +64,13 @@ impl<'assertion> RequestCtap1 for CheckKeyHandle<'assertion> {
             Ok(_) | Err(ApduErrorStatus::ConditionsNotSatisfied) => Ok(()),
             Err(e) => Err(Retryable::Error(HIDError::ApduStatus(e))),
         }
+    }
+
+    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
+        &self,
+        dev: &mut Dev,
+    ) -> Result<Self::Output, HIDError> {
+        dev.check_key_handle(self)
     }
 }
 

--- a/src/transport/freebsd/device.rs
+++ b/src/transport/freebsd/device.rs
@@ -8,7 +8,7 @@ use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::uhid;
-use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::from_unix_result;
 use crate::util::io_err;
@@ -186,15 +186,6 @@ impl HIDDevice for Device {
 impl FidoDevice for Device {
     fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
         HIDDevice::pre_init(self, noncecmd)
-    }
-
-    fn sendrecv(
-        &mut self,
-        cmd: HIDCmd,
-        send: &[u8],
-        keep_alive: &dyn Fn() -> bool,
-    ) -> io::Result<(HIDCmd, Vec<u8>)> {
-        HIDDevice::sendrecv(self, cmd, send, keep_alive)
     }
 
     fn should_try_ctap2(&self) -> bool {

--- a/src/transport/linux/device.rs
+++ b/src/transport/linux/device.rs
@@ -7,7 +7,7 @@ use crate::consts::{Capability, CID_BROADCAST};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::{hidraw, monitor};
-use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::from_unix_result;
 use std::fs::OpenOptions;
@@ -138,15 +138,6 @@ impl HIDDevice for Device {
 impl FidoDevice for Device {
     fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
         HIDDevice::pre_init(self, noncecmd)
-    }
-
-    fn sendrecv(
-        &mut self,
-        cmd: HIDCmd,
-        send: &[u8],
-        keep_alive: &dyn Fn() -> bool,
-    ) -> io::Result<(HIDCmd, Vec<u8>)> {
-        HIDDevice::sendrecv(self, cmd, send, keep_alive)
     }
 
     fn should_try_ctap2(&self) -> bool {

--- a/src/transport/macos/device.rs
+++ b/src/transport/macos/device.rs
@@ -8,7 +8,7 @@ use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::iokit::*;
-use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use core_foundation::base::*;
 use core_foundation::string::*;
@@ -186,15 +186,6 @@ impl HIDDevice for Device {
 impl FidoDevice for Device {
     fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
         HIDDevice::pre_init(self, noncecmd)
-    }
-
-    fn sendrecv(
-        &mut self,
-        cmd: HIDCmd,
-        send: &[u8],
-        keep_alive: &dyn Fn() -> bool,
-    ) -> io::Result<(HIDCmd, Vec<u8>)> {
-        HIDDevice::sendrecv(self, cmd, send, keep_alive)
     }
 
     fn should_try_ctap2(&self) -> bool {

--- a/src/transport/mock/device.rs
+++ b/src/transport/mock/device.rs
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use crate::consts::{Capability, HIDCmd, CID_BROADCAST};
+use crate::consts::{Capability, CID_BROADCAST};
 use crate::crypto::SharedSecret;
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::device_selector::DeviceCommand;
@@ -159,15 +159,6 @@ impl HIDDevice for Device {
 impl FidoDevice for Device {
     fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
         HIDDevice::pre_init(self, noncecmd)
-    }
-
-    fn sendrecv(
-        &mut self,
-        cmd: HIDCmd,
-        send: &[u8],
-        keep_alive: &dyn Fn() -> bool,
-    ) -> io::Result<(HIDCmd, Vec<u8>)> {
-        HIDDevice::sendrecv(self, cmd, send, keep_alive)
     }
 
     fn should_try_ctap2(&self) -> bool {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,13 +1,18 @@
 use crate::crypto::{PinUvAuthProtocol, PinUvAuthToken, SharedSecret};
 use crate::ctap2::commands::client_pin::{
-    GetKeyAgreement, GetPinToken, GetPinUvAuthTokenUsingPinWithPermissions,
+    ClientPINSubCommand, GetKeyAgreement, GetPinToken, GetPinUvAuthTokenUsingPinWithPermissions,
     GetPinUvAuthTokenUsingUvWithPermissions, PinUvAuthTokenPermission,
 };
+use crate::ctap2::commands::get_assertion::{GetAssertion, GetAssertionResult};
 use crate::ctap2::commands::get_info::{AuthenticatorInfo, AuthenticatorVersion, GetInfo};
-use crate::ctap2::commands::get_version::GetVersion;
-use crate::ctap2::commands::make_credentials::dummy_make_credentials_cmd;
+use crate::ctap2::commands::get_version::{U2FInfo, GetVersion};
+use crate::ctap2::commands::make_credentials::{
+    dummy_make_credentials_cmd, MakeCredentials, MakeCredentialsResult,
+};
+use crate::ctap2::commands::reset::Reset;
 use crate::ctap2::commands::selection::Selection;
 use crate::ctap2::commands::{CommandError, Request, RequestCtap1, RequestCtap2, StatusCode};
+use crate::ctap2::preflight::CheckKeyHandle;
 use crate::transport::device_selector::BlinkResult;
 use crate::transport::errors::HIDError;
 
@@ -280,4 +285,15 @@ where
 
         Ok(pin_auth_token)
     }
+}
+
+pub trait VirtualFidoDevice: FidoDevice {
+    fn check_key_handle(&self, req: &CheckKeyHandle) -> Result<(), HIDError>;
+    fn client_pin<T: ClientPINSubCommand>(&self, req: &T) -> Result<T::Output, HIDError>;
+    fn get_assertion(&self, req: &GetAssertion) -> Result<GetAssertionResult, HIDError>;
+    fn get_info(&self) -> Result<AuthenticatorInfo, HIDError>;
+    fn get_version(&self, req: &GetVersion) -> Result<U2FInfo, HIDError>;
+    fn make_credentials(&self, req: &MakeCredentials) -> Result<MakeCredentialsResult, HIDError>;
+    fn reset(&self, req: &Reset) -> Result<(), HIDError>;
+    fn selection(&self, req: &Selection) -> Result<(), HIDError>;
 }

--- a/src/transport/netbsd/device.rs
+++ b/src/transport/netbsd/device.rs
@@ -9,7 +9,7 @@ use crate::transport::hid::HIDDevice;
 use crate::transport::platform::fd::Fd;
 use crate::transport::platform::monitor::WrappedOpenDevice;
 use crate::transport::platform::uhid;
-use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::io_err;
 use std::ffi::OsString;
@@ -188,15 +188,6 @@ impl HIDDevice for Device {
 impl FidoDevice for Device {
     fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
         HIDDevice::pre_init(self, noncecmd)
-    }
-
-    fn sendrecv(
-        &mut self,
-        cmd: HIDCmd,
-        send: &[u8],
-        keep_alive: &dyn Fn() -> bool,
-    ) -> io::Result<(HIDCmd, Vec<u8>)> {
-        HIDDevice::sendrecv(self, cmd, send, keep_alive)
     }
 
     fn should_try_ctap2(&self) -> bool {

--- a/src/transport/openbsd/device.rs
+++ b/src/transport/openbsd/device.rs
@@ -7,7 +7,7 @@ use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::monitor::WrappedOpenDevice;
-use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::{from_unix_result, io_err};
 use std::ffi::{CString, OsString};
@@ -169,15 +169,6 @@ impl HIDDevice for Device {
 impl FidoDevice for Device {
     fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
         HIDDevice::pre_init(self, noncecmd)
-    }
-
-    fn sendrecv(
-        &mut self,
-        cmd: HIDCmd,
-        send: &[u8],
-        keep_alive: &dyn Fn() -> bool,
-    ) -> io::Result<(HIDCmd, Vec<u8>)> {
-        HIDDevice::sendrecv(self, cmd, send, keep_alive)
     }
 
     fn should_try_ctap2(&self) -> bool {

--- a/src/transport/stub/device.rs
+++ b/src/transport/stub/device.rs
@@ -4,7 +4,7 @@
 
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
-use crate::transport::{FidoDevice, FidoProtocol, HIDCmd};
+use crate::transport::{FidoDevice, FidoProtocol};
 use crate::transport::{HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use std::hash::Hash;
@@ -74,15 +74,6 @@ impl HIDDevice for Device {
 
 impl FidoDevice for Device {
     fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
-        unimplemented!();
-    }
-
-    fn sendrecv(
-        &mut self,
-        cmd: HIDCmd,
-        send: &[u8],
-        keep_alive: &dyn Fn() -> bool,
-    ) -> io::Result<(HIDCmd, Vec<u8>)> {
         unimplemented!();
     }
 

--- a/src/transport/windows/device.rs
+++ b/src/transport/windows/device.rs
@@ -8,7 +8,7 @@ use crate::consts::{
 };
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
-use crate::transport::{FidoDevice, FidoProtocol, HIDCmd, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};
@@ -127,15 +127,6 @@ impl HIDDevice for Device {
 impl FidoDevice for Device {
     fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
         HIDDevice::pre_init(self, noncecmd)
-    }
-
-    fn sendrecv(
-        &mut self,
-        cmd: HIDCmd,
-        send: &[u8],
-        keep_alive: &dyn Fn() -> bool,
-    ) -> io::Result<(HIDCmd, Vec<u8>)> {
-        HIDDevice::sendrecv(self, cmd, send, keep_alive)
     }
 
     fn should_try_ctap2(&self) -> bool {


### PR DESCRIPTION
The first patch factors `send_msg` (and specializations of it) out of `FidoDevice` and into a new `FidoDeviceIO` trait. This lets us remove `FidoDevice::sendrecv`, which was the last truly HID-specific part of `FidoDevice`.

The second patch adds a `VirtualFidoDevice` trait. A `VirtualFidoDevice` defines how to map a concrete `Request` type (something like a `MakeCredential`) to its associated `Request::Output` type (something like a `MakeCredentialResult`). The patch also adds a `send_to_virtual_device` function to the request trait. The signature of `Request::send_to_virtual_device` is
```rust
    fn send_to_virtual_device<Dev: VirtualFidoDevice>(
        &self, // : Request<Out>
        dev: &mut Dev,
    ) -> Result<Self::Output, HIDError>;
```
which is compatible with `FidoDeviceIO::send_msg` and its specializations. This lets us implement, e.g., `FidoDeviceIO::send_cbor` as
```rust
    fn send_cbor<Req: RequestCtap2>(
        &mut self,
        msg: &Req,
    ) -> Result<Req::Output, HIDError> {
        msg.send_to_virtual_device(self)
    }
```

We could have used the existing `Request` functions, e.g.
```rust
    fn send_cbor<Req: RequestCtap2>(
        &mut self,
        msg: &Req,
    ) -> Result<Req::Output, HIDError> {
        let data = msg.wire_format()?
        let resp = ... // process data and return serialized response
        msg.handle_response_ctap2(self, &resp)?
    }
```
But then we would need virtual devices to act on CBOR (or CTAP1 messages) and produce *serialized* responses. This approach lets us avoid implementing serialize for each `Request::Output` type.