### PR TITLE
Visibility changes for virtual authenticators

### DIFF
--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -7,12 +7,13 @@ use authenticator::{
         AuthenticatorService, GetAssertionExtensions, HmacSecretExtension,
         MakeCredentialsExtensions, RegisterArgs, SignArgs,
     },
+    crypto::COSEAlgorithm,
     ctap2::server::{
         PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
         ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
     },
     statecallback::StateCallback,
-    COSEAlgorithm, Pin, RegisterResult, SignResult, StatusPinUv, StatusUpdate,
+    Pin, RegisterResult, SignResult, StatusPinUv, StatusUpdate,
 };
 use getopts::Options;
 use sha2::{Digest, Sha256};

--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -4,12 +4,13 @@
 
 use authenticator::{
     authenticatorservice::{AuthenticatorService, RegisterArgs, SignArgs},
+    crypto::COSEAlgorithm,
     ctap2::server::{
         PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
         ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
     },
     statecallback::StateCallback,
-    COSEAlgorithm, Pin, RegisterResult, SignResult, StatusPinUv, StatusUpdate,
+    Pin, RegisterResult, SignResult, StatusPinUv, StatusUpdate,
 };
 use getopts::Options;
 use sha2::{Digest, Sha256};

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -4,6 +4,7 @@
 
 use authenticator::{
     authenticatorservice::{AuthenticatorService, GetAssertionExtensions, RegisterArgs, SignArgs},
+    crypto::COSEAlgorithm,
     ctap2::commands::StatusCode,
     ctap2::server::{
         PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
@@ -11,7 +12,7 @@ use authenticator::{
     },
     errors::{AuthenticatorError, CommandError, HIDError, UnsupportedOption},
     statecallback::StateCallback,
-    COSEAlgorithm, Pin, RegisterResult, SignResult, StatusPinUv, StatusUpdate,
+    Pin, RegisterResult, SignResult, StatusPinUv, StatusUpdate,
 };
 
 use getopts::Options;

--- a/src/ctap2/commands/client_pin.rs
+++ b/src/ctap2/commands/client_pin.rs
@@ -148,7 +148,7 @@ pub trait ClientPINSubCommand {
 #[derive(Default)]
 pub struct ClientPinResponse {
     pub key_agreement: Option<COSEKey>,
-    pub pin_token: Option<EncryptedPinToken>,
+    pub pin_token: Option<Vec<u8>>,
     /// Number of PIN attempts remaining before lockout.
     pub pin_retries: Option<u8>,
     pub power_cycle_state: Option<bool>,
@@ -630,15 +630,6 @@ where
         dev: &mut Dev,
     ) -> Result<ClientPinResponse, HIDError> {
         dev.client_pin(&self.as_client_pin()?)
-    }
-}
-
-#[derive(Debug, Deserialize)]
-pub struct EncryptedPinToken(ByteBuf);
-
-impl AsRef<[u8]> for EncryptedPinToken {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
     }
 }
 

--- a/src/ctap2/commands/client_pin.rs
+++ b/src/ctap2/commands/client_pin.rs
@@ -55,14 +55,14 @@ impl Default for PinUvAuthTokenPermission {
 
 #[derive(Debug)]
 pub struct ClientPIN {
-    pin_protocol: Option<PinUvAuthProtocol>,
-    subcommand: PINSubcommand,
-    key_agreement: Option<COSEKey>,
-    pin_auth: Option<ByteBuf>,
-    new_pin_enc: Option<ByteBuf>,
-    pin_hash_enc: Option<ByteBuf>,
-    permissions: Option<u8>,
-    rp_id: Option<String>,
+    pub pin_protocol: Option<PinUvAuthProtocol>,
+    pub subcommand: PINSubcommand,
+    pub key_agreement: Option<COSEKey>,
+    pub pin_auth: Option<ByteBuf>,
+    pub new_pin_enc: Option<ByteBuf>,
+    pub pin_hash_enc: Option<ByteBuf>,
+    pub permissions: Option<u8>,
+    pub rp_id: Option<String>,
 }
 
 impl Default for ClientPIN {
@@ -371,7 +371,7 @@ impl<'sc, 'pin> ClientPINSubCommand for GetPinUvAuthTokenUsingPinWithPermissions
 
 macro_rules! implementRetries {
     ($name:ident, $getter:ident) => {
-        #[derive(Debug)]
+        #[derive(Debug, Default)]
         pub struct $name {}
 
         impl $name {

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -157,9 +157,9 @@ impl GetAssertionExtensions {
 
 #[derive(Debug, Clone)]
 pub struct GetAssertion {
-    pub(crate) client_data_hash: ClientDataHash,
-    pub(crate) rp: RelyingPartyWrapper,
-    pub(crate) allow_list: Vec<PublicKeyCredentialDescriptor>,
+    pub client_data_hash: ClientDataHash,
+    pub rp: RelyingPartyWrapper,
+    pub allow_list: Vec<PublicKeyCredentialDescriptor>,
 
     // https://www.w3.org/TR/webauthn/#client-extension-input
     // The client extension input, which is a value that can be encoded in JSON,
@@ -167,13 +167,13 @@ pub struct GetAssertion {
     // create() call, while the CBOR authenticator extension input is passed
     // from the client to the authenticator for authenticator extensions during
     // the processing of these calls.
-    pub(crate) extensions: GetAssertionExtensions,
-    pub(crate) options: GetAssertionOptions,
-    pub(crate) pin: Option<Pin>,
-    pub(crate) pin_uv_auth_param: Option<PinUvAuthParam>,
+    pub extensions: GetAssertionExtensions,
+    pub options: GetAssertionOptions,
+    pub pin: Option<Pin>,
+    pub pin_uv_auth_param: Option<PinUvAuthParam>,
 
     // This is used to implement the FIDO AppID extension.
-    pub(crate) alternate_rp_id: Option<String>,
+    pub alternate_rp_id: Option<String>,
 }
 
 impl GetAssertion {
@@ -505,12 +505,12 @@ impl GetAssertionResult {
     }
 }
 
-pub(crate) struct GetAssertionResponse {
-    credentials: Option<PublicKeyCredentialDescriptor>,
-    auth_data: AuthenticatorData,
-    signature: Vec<u8>,
-    user: Option<User>,
-    number_of_credentials: Option<usize>,
+pub struct GetAssertionResponse {
+    pub credentials: Option<PublicKeyCredentialDescriptor>,
+    pub auth_data: AuthenticatorData,
+    pub signature: Vec<u8>,
+    pub user: Option<User>,
+    pub number_of_credentials: Option<usize>,
 }
 
 impl<'de> Deserialize<'de> for GetAssertionResponse {

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -543,7 +543,7 @@ pub mod tests {
     use crate::crypto::COSEAlgorithm;
     use crate::transport::device_selector::Device;
     use crate::transport::platform::device::IN_HID_RPT_SIZE;
-    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol, Nonce};
+    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
     use rand::{thread_rng, RngCore};
     use serde_cbor::de::from_slice;
 
@@ -904,9 +904,7 @@ pub mod tests {
         msg.extend(vec![0x00]); // SEQ
         msg.extend(&AUTHENTICATOR_INFO_PAYLOAD[(IN_HID_RPT_SIZE - 8)..]);
         device.add_read(&msg, 0);
-        device
-            .init(Nonce::Use(nonce))
-            .expect("Failed to init device");
+        device.init().expect("Failed to init device");
 
         assert_eq!(device.get_cid(), &cid);
 

--- a/src/ctap2/commands/get_version.rs
+++ b/src/ctap2/commands/get_version.rs
@@ -58,7 +58,7 @@ impl RequestCtap1 for GetVersion {
 pub mod tests {
     use crate::consts::{Capability, HIDCmd, CID_BROADCAST, SW_NO_ERROR};
     use crate::transport::device_selector::Device;
-    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol, Nonce};
+    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
     use rand::{thread_rng, RngCore};
 
     #[test]
@@ -104,9 +104,7 @@ pub mod tests {
         msg.extend(SW_NO_ERROR);
         device.add_read(&msg, 0);
 
-        device
-            .init(Nonce::Use(nonce))
-            .expect("Failed to init device");
+        device.init().expect("Failed to init device");
 
         assert_eq!(device.get_cid(), &cid);
 

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -153,12 +153,12 @@ impl MakeCredentialsExtensions {
 
 #[derive(Debug, Clone)]
 pub struct MakeCredentials {
-    pub(crate) client_data_hash: ClientDataHash,
-    pub(crate) rp: RelyingPartyWrapper,
+    pub client_data_hash: ClientDataHash,
+    pub rp: RelyingPartyWrapper,
     // Note(baloo): If none -> ctap1
-    pub(crate) user: Option<User>,
-    pub(crate) pub_cred_params: Vec<PublicKeyCredentialParameters>,
-    pub(crate) exclude_list: Vec<PublicKeyCredentialDescriptor>,
+    pub user: Option<User>,
+    pub pub_cred_params: Vec<PublicKeyCredentialParameters>,
+    pub exclude_list: Vec<PublicKeyCredentialDescriptor>,
 
     // https://www.w3.org/TR/webauthn/#client-extension-input
     // The client extension input, which is a value that can be encoded in JSON,
@@ -166,11 +166,11 @@ pub struct MakeCredentials {
     // create() call, while the CBOR authenticator extension input is passed
     // from the client to the authenticator for authenticator extensions during
     // the processing of these calls.
-    pub(crate) extensions: MakeCredentialsExtensions,
-    pub(crate) options: MakeCredentialsOptions,
-    pub(crate) pin: Option<Pin>,
-    pub(crate) pin_uv_auth_param: Option<PinUvAuthParam>,
-    pub(crate) enterprise_attestation: Option<u64>,
+    pub extensions: MakeCredentialsExtensions,
+    pub options: MakeCredentialsOptions,
+    pub pin: Option<Pin>,
+    pub pin_uv_auth_param: Option<PinUvAuthParam>,
+    pub enterprise_attestation: Option<u64>,
 }
 
 impl MakeCredentials {
@@ -443,7 +443,7 @@ pub(crate) fn dummy_make_credentials_cmd() -> MakeCredentials {
             ..Default::default()
         }),
         vec![PublicKeyCredentialParameters {
-            alg: crate::COSEAlgorithm::ES256,
+            alg: COSEAlgorithm::ES256,
         }],
         vec![],
         MakeCredentialsOptions::default(),

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -13,14 +13,14 @@ use serde_json as json;
 use std::error::Error as StdErrorT;
 use std::fmt;
 
-pub(crate) mod client_pin;
-pub(crate) mod get_assertion;
-pub(crate) mod get_info;
-pub(crate) mod get_next_assertion;
-pub(crate) mod get_version;
-pub(crate) mod make_credentials;
-pub(crate) mod reset;
-pub(crate) mod selection;
+pub mod client_pin;
+pub mod get_assertion;
+pub mod get_info;
+pub mod get_next_assertion;
+pub mod get_version;
+pub mod make_credentials;
+pub mod reset;
+pub mod selection;
 
 pub trait Request<T>
 where

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -1,11 +1,8 @@
+pub mod attestation;
+pub mod client_data;
 #[allow(dead_code)] // TODO(MS): Remove me asap
 pub mod commands;
-pub use commands::get_assertion::GetAssertionResult;
-
-pub mod attestation;
-
-pub mod client_data;
-pub(crate) mod preflight;
+pub mod preflight;
 pub mod server;
 pub(crate) mod utils;
 
@@ -35,9 +32,10 @@ use crate::errors::{AuthenticatorError, UnsupportedOption};
 use crate::statecallback::StateCallback;
 use crate::transport::device_selector::{Device, DeviceSelectorEvent};
 
+use crate::status_update::send_status;
 use crate::transport::{errors::HIDError, hid::HIDDevice, FidoDevice, FidoDeviceIO, FidoProtocol};
 
-use crate::{send_status, RegisterResult, SignResult, StatusPinUv, StatusUpdate};
+use crate::{RegisterResult, SignResult, StatusPinUv, StatusUpdate};
 use std::sync::mpsc::{channel, RecvError, Sender};
 use std::thread;
 use std::time::Duration;
@@ -682,7 +680,7 @@ pub fn sign<Dev: FidoDevice>(
     false
 }
 
-pub fn reset_helper(
+pub(crate) fn reset_helper(
     dev: &mut Device,
     selector: Sender<DeviceSelectorEvent>,
     status: Sender<crate::StatusUpdate>,
@@ -716,7 +714,7 @@ pub fn reset_helper(
     }
 }
 
-pub fn set_or_change_pin_helper(
+pub(crate) fn set_or_change_pin_helper(
     dev: &mut Device,
     mut current_pin: Option<Pin>,
     new_pin: Pin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,32 +27,25 @@ extern crate runloop;
 #[macro_use]
 extern crate bitflags;
 
-pub mod authenticatorservice;
 mod consts;
+mod manager;
 mod statemachine;
+mod status_update;
+mod transport;
 mod u2fprotocol;
 mod u2ftypes;
 
-mod manager;
-
+pub mod authenticatorservice;
+pub mod crypto;
 pub mod ctap2;
-pub use ctap2::attestation::AttestationObject;
-pub use ctap2::client_data::CollectedClientData;
-pub use ctap2::commands::client_pin::{Pin, PinError};
-pub use ctap2::commands::get_assertion::Assertion;
-pub use ctap2::commands::get_info::AuthenticatorInfo;
-pub use ctap2::GetAssertionResult;
-
 pub mod errors;
 pub mod statecallback;
-mod transport;
-mod virtualdevices;
-
-mod status_update;
-pub use status_update::*;
-
-mod crypto;
-pub use crypto::COSEAlgorithm;
+pub use ctap2::attestation::AttestationObject;
+pub use ctap2::commands::client_pin::{Pin, PinError};
+pub use ctap2::commands::get_assertion::{Assertion, GetAssertionResult};
+pub use ctap2::commands::get_info::AuthenticatorInfo;
+pub use status_update::{InteractiveRequest, StatusPinUv, StatusUpdate};
+pub use transport::{FidoDevice, FidoDeviceIO, FidoProtocol, VirtualFidoDevice};
 
 // Keep this in sync with the constants in u2fhid-capi.h.
 bitflags! {

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -21,7 +21,7 @@ use crate::transport::device_selector::{
     BlinkResult, Device, DeviceBuildParameters, DeviceCommand, DeviceSelectorEvent,
 };
 use crate::transport::platform::transaction::Transaction;
-use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol, Nonce};
+use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
 use crate::u2fprotocol::{u2f_init_device, u2f_is_keyhandle_valid, u2f_register, u2f_sign};
 use crate::{
     send_status, AuthenticatorTransports, InteractiveRequest, KeyHandle, RegisterFlags,
@@ -88,7 +88,7 @@ impl StateMachine {
         };
 
         // Try initializing it.
-        if let Err(e) = dev.init(Nonce::CreateRandom) {
+        if let Err(e) = dev.init() {
             warn!("error while initializing device: {}", e);
             selector.send(DeviceSelectorEvent::NotAToken(dev.id())).ok();
             return None;

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -17,6 +17,7 @@ use crate::ctap2::server::{
 };
 use crate::errors::{self, AuthenticatorError};
 use crate::statecallback::StateCallback;
+use crate::status_update::send_status;
 use crate::transport::device_selector::{
     BlinkResult, Device, DeviceBuildParameters, DeviceCommand, DeviceSelectorEvent,
 };
@@ -24,8 +25,8 @@ use crate::transport::platform::transaction::Transaction;
 use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
 use crate::u2fprotocol::{u2f_init_device, u2f_is_keyhandle_valid, u2f_register, u2f_sign};
 use crate::{
-    send_status, AuthenticatorTransports, InteractiveRequest, KeyHandle, RegisterFlags,
-    RegisterResult, SignFlags, SignResult,
+    AuthenticatorTransports, InteractiveRequest, KeyHandle, RegisterFlags, RegisterResult,
+    SignFlags, SignResult,
 };
 use std::sync::mpsc::{channel, RecvTimeoutError, Sender};
 use std::thread;

--- a/src/status_update.rs
+++ b/src/status_update.rs
@@ -63,12 +63,7 @@ pub enum StatusUpdate {
     /// Sent, if multiple devices are found and the user has to select one
     SelectDeviceNotice,
     /// Sent when a token was selected for interactive management
-    InteractiveManagement(
-        (
-            Sender<InteractiveRequest>,
-            Option<AuthenticatorInfo>,
-        ),
-    ),
+    InteractiveManagement((Sender<InteractiveRequest>, Option<AuthenticatorInfo>)),
 }
 
 pub(crate) fn send_status(status: &Sender<StatusUpdate>, msg: StatusUpdate) {

--- a/src/transport/freebsd/device.rs
+++ b/src/transport/freebsd/device.rs
@@ -8,7 +8,7 @@ use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::uhid;
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::from_unix_result;
 use crate::util::io_err;
@@ -184,8 +184,8 @@ impl HIDDevice for Device {
 }
 
 impl FidoDevice for Device {
-    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
-        HIDDevice::pre_init(self, noncecmd)
+    fn pre_init(&mut self) -> Result<(), HIDError> {
+        HIDDevice::pre_init(self)
     }
 
     fn should_try_ctap2(&self) -> bool {

--- a/src/transport/linux/device.rs
+++ b/src/transport/linux/device.rs
@@ -7,7 +7,7 @@ use crate::consts::{Capability, CID_BROADCAST};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::{hidraw, monitor};
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::from_unix_result;
 use std::fs::OpenOptions;
@@ -136,8 +136,8 @@ impl HIDDevice for Device {
 }
 
 impl FidoDevice for Device {
-    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
-        HIDDevice::pre_init(self, noncecmd)
+    fn pre_init(&mut self) -> Result<(), HIDError> {
+        HIDDevice::pre_init(self)
     }
 
     fn should_try_ctap2(&self) -> bool {

--- a/src/transport/macos/device.rs
+++ b/src/transport/macos/device.rs
@@ -8,7 +8,7 @@ use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::iokit::*;
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use core_foundation::base::*;
 use core_foundation::string::*;
@@ -184,8 +184,8 @@ impl HIDDevice for Device {
 }
 
 impl FidoDevice for Device {
-    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
-        HIDDevice::pre_init(self, noncecmd)
+    fn pre_init(&mut self) -> Result<(), HIDError> {
+        HIDDevice::pre_init(self)
     }
 
     fn should_try_ctap2(&self) -> bool {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -71,12 +71,6 @@ pub mod platform;
 #[path = "mock/mod.rs"]
 pub mod platform;
 
-#[derive(Debug)]
-pub enum Nonce {
-    CreateRandom,
-    Use([u8; 8]),
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FidoProtocol {
     CTAP1,
@@ -120,7 +114,7 @@ where
     Self: Sized,
     Self: fmt::Debug,
 {
-    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError>;
+    fn pre_init(&mut self) -> Result<(), HIDError>;
     fn initialized(&self) -> bool;
 
     // Check if the device is actually a token
@@ -142,8 +136,8 @@ where
     fn get_shared_secret(&self) -> Option<&SharedSecret>;
     fn set_shared_secret(&mut self, secret: SharedSecret);
 
-    fn init(&mut self, nonce: Nonce) -> Result<(), HIDError> {
-        self.pre_init(nonce)?;
+    fn init(&mut self) -> Result<(), HIDError> {
+        self.pre_init()?;
 
         if self.should_try_ctap2() {
             let command = GetInfo::default();

--- a/src/transport/netbsd/device.rs
+++ b/src/transport/netbsd/device.rs
@@ -9,7 +9,7 @@ use crate::transport::hid::HIDDevice;
 use crate::transport::platform::fd::Fd;
 use crate::transport::platform::monitor::WrappedOpenDevice;
 use crate::transport::platform::uhid;
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::io_err;
 use std::ffi::OsString;
@@ -186,8 +186,8 @@ impl HIDDevice for Device {
 }
 
 impl FidoDevice for Device {
-    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
-        HIDDevice::pre_init(self, noncecmd)
+    fn pre_init(&mut self) -> Result<(), HIDError> {
+        HIDDevice::pre_init(self)
     }
 
     fn should_try_ctap2(&self) -> bool {

--- a/src/transport/openbsd/device.rs
+++ b/src/transport/openbsd/device.rs
@@ -7,7 +7,7 @@ use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::monitor::WrappedOpenDevice;
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::{from_unix_result, io_err};
 use std::ffi::{CString, OsString};
@@ -167,8 +167,8 @@ impl HIDDevice for Device {
 }
 
 impl FidoDevice for Device {
-    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
-        HIDDevice::pre_init(self, noncecmd)
+    fn pre_init(&mut self) -> Result<(), HIDError> {
+        HIDDevice::pre_init(self)
     }
 
     fn should_try_ctap2(&self) -> bool {

--- a/src/transport/stub/device.rs
+++ b/src/transport/stub/device.rs
@@ -5,7 +5,7 @@
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::{FidoDevice, FidoProtocol};
-use crate::transport::{HIDError, Nonce, SharedSecret};
+use crate::transport::{HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use std::hash::Hash;
 use std::io;
@@ -73,7 +73,7 @@ impl HIDDevice for Device {
 }
 
 impl FidoDevice for Device {
-    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
+    fn pre_init(&mut self) -> Result<(), HIDError> {
         unimplemented!();
     }
 

--- a/src/transport/windows/device.rs
+++ b/src/transport/windows/device.rs
@@ -8,7 +8,7 @@ use crate::consts::{
 };
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, Nonce, SharedSecret};
+use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};
@@ -125,8 +125,8 @@ impl HIDDevice for Device {
 }
 
 impl FidoDevice for Device {
-    fn pre_init(&mut self, noncecmd: Nonce) -> Result<(), HIDError> {
-        HIDDevice::pre_init(self, noncecmd)
+    fn pre_init(&mut self) -> Result<(), HIDError> {
+        HIDDevice::pre_init(self)
     }
 
     fn should_try_ctap2(&self) -> bool {


### PR DESCRIPTION
Consumers of this library should be able to implement their own virtual authenticators, and this requires some visibility changes.

This PR also removes the `EncryptedPinToken` type, which just wrapped a `Vec<u8>`, and the `Nonce` type, which was only useful for two tests. To remove `Nonce` I had to implement `HIDDevice::pre_init` for the mock device. I think that's a small cost to avoid having `Nonce` in the `FidoDevice` trait.