### PR TITLE
Add support for ECDSA over P256 using NSS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ cfg-if = "1.0"
 # Crypto backends
 openssl-sys = { version = "0.9", optional = true}
 openssl = { version = "0.10", optional = true}
-nss-gk-api = { version = "0.2.1", optional = true }
+nss-gk-api = { version = "0.3.0", optional = true }
 pkcs11-bindings = { version = "0.1.4", optional = true }
 
 [dev-dependencies]

--- a/src/crypto/dummy.rs
+++ b/src/crypto/dummy.rs
@@ -46,6 +46,7 @@ pub fn ecdsa_p256_sha256_sign_raw(_private: &[u8], _data: &[u8]) -> Result<Vec<u
     unimplemented!()
 }
 
+#[allow(dead_code)]
 #[cfg(test)]
 pub fn test_ecdsa_p256_sha256_verify_raw(
     _public: &[u8],

--- a/src/crypto/dummy.rs
+++ b/src/crypto/dummy.rs
@@ -37,3 +37,20 @@ pub fn sha256(_data: &[u8]) -> Result<Vec<u8>> {
 pub fn random_bytes(_count: usize) -> Result<Vec<u8>> {
     unimplemented!()
 }
+
+pub fn gen_p256() -> Result<(Vec<u8>, Vec<u8>)> {
+    unimplemented!()
+}
+
+pub fn ecdsa_p256_sha256_sign_raw(_private: &[u8], _data: &[u8]) -> Result<Vec<u8>> {
+    unimplemented!()
+}
+
+#[cfg(test)]
+pub fn test_ecdsa_p256_sha256_verify_raw(
+    _public: &[u8],
+    _signature: &[u8],
+    _data: &[u8],
+) -> Result<()> {
+    unimplemented!()
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1162,10 +1162,11 @@ pub fn parse_u2f_der_certificate(data: &[u8]) -> Result<U2FRegisterAnswer, Crypt
 mod test {
     use std::convert::TryFrom;
 
+    #[cfg(feature = "crypto_nss")]
+    use super::backend::{ecdsa_p256_sha256_sign_raw, test_ecdsa_p256_sha256_verify_raw};
     use super::{
-        backend::ecdsa_p256_sha256_sign_raw, backend::hmac_sha256, backend::sha256,
-        backend::test_ecdh_p256_raw, backend::test_ecdsa_p256_sha256_verify_raw, COSEAlgorithm,
-        COSEKey, Curve, PinProtocolImpl, PinUvAuth1, PinUvAuth2, PinUvAuthProtocol, PublicInputs,
+        backend::hmac_sha256, backend::sha256, backend::test_ecdh_p256_raw, COSEAlgorithm, COSEKey,
+        Curve, PinProtocolImpl, PinUvAuth1, PinUvAuth2, PinUvAuthProtocol, PublicInputs,
         SharedSecret,
     };
     use crate::crypto::{COSEEC2Key, COSEKeyType};

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -887,13 +887,13 @@ impl COSEKey {
     /// Generates a new key pair for the specified algorithm.
     /// Returns an PKCS#8 encoding of the private key, and the public key as a COSEKey.
     pub fn generate(alg: COSEAlgorithm) -> Result<(Vec<u8>, Self), CryptoError> {
-        if alg != COSEAlgorithm::ES256 {
+        if alg != COSEAlgorithm::ES256 && alg != COSEAlgorithm::ECDH_ES_HKDF256 {
             return Err(CryptoError::UnsupportedAlgorithm(alg));
         }
         let (private, public) = gen_p256()?;
         let cose_ec2_key = COSEEC2Key::from_sec1_uncompressed(Curve::SECP256R1, &public)?;
         let public = COSEKey {
-            alg: COSEAlgorithm::ES256,
+            alg,
             key: COSEKeyType::EC2(cose_ec2_key),
         };
         Ok((private, public))

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -32,9 +32,11 @@ mod dummy;
 use dummy as backend;
 
 use backend::{
-    decrypt_aes_256_cbc_no_pad, ecdhe_p256_raw, encrypt_aes_256_cbc_no_pad, hmac_sha256,
+    decrypt_aes_256_cbc_no_pad, ecdhe_p256_raw, encrypt_aes_256_cbc_no_pad, gen_p256, hmac_sha256,
     random_bytes, sha256,
 };
+
+pub use backend::ecdsa_p256_sha256_sign_raw;
 
 // Object identifiers in DER tag-length-value form
 const DER_OID_EC_PUBLIC_KEY_BYTES: &[u8] = &[
@@ -881,6 +883,23 @@ pub struct COSEKey {
     pub key: COSEKeyType,
 }
 
+impl COSEKey {
+    /// Generates a new key pair for the specified algorithm.
+    /// Returns an PKCS#8 encoding of the private key, and the public key as a COSEKey.
+    pub fn generate(alg: COSEAlgorithm) -> Result<(Vec<u8>, Self), CryptoError> {
+        if alg != COSEAlgorithm::ES256 {
+            return Err(CryptoError::UnsupportedAlgorithm(alg));
+        }
+        let (private, public) = gen_p256()?;
+        let cose_ec2_key = COSEEC2Key::from_sec1_uncompressed(Curve::SECP256R1, &public)?;
+        let public = COSEKey {
+            alg: COSEAlgorithm::ES256,
+            key: COSEKeyType::EC2(cose_ec2_key),
+        };
+        Ok((private, public))
+    }
+}
+
 impl<'de> Deserialize<'de> for COSEKey {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
@@ -1144,8 +1163,9 @@ mod test {
     use std::convert::TryFrom;
 
     use super::{
-        backend::hmac_sha256, backend::sha256, backend::test_ecdh_p256_raw, COSEAlgorithm, COSEKey,
-        Curve, PinProtocolImpl, PinUvAuth1, PinUvAuth2, PinUvAuthProtocol, PublicInputs,
+        backend::ecdsa_p256_sha256_sign_raw, backend::hmac_sha256, backend::sha256,
+        backend::test_ecdh_p256_raw, backend::test_ecdsa_p256_sha256_verify_raw, COSEAlgorithm,
+        COSEKey, Curve, PinProtocolImpl, PinUvAuth1, PinUvAuth2, PinUvAuthProtocol, PublicInputs,
         SharedSecret,
     };
     use crate::crypto::{COSEEC2Key, COSEKeyType};
@@ -1412,5 +1432,52 @@ mod test {
         ];
         let pin = PinUvAuthProtocol::try_from(&info).unwrap();
         assert_eq!(pin.id(), 2);
+    }
+
+    #[test]
+    #[cfg(feature = "crypto_nss")]
+    fn test_sign() {
+        let (good_private, good_public) =
+            COSEKey::generate(COSEAlgorithm::ES256).expect("could not generate a key pair");
+        let good_spki = match good_public.key {
+            COSEKeyType::EC2(ref x) => x.der_spki().expect("could not serialize public key"),
+            _ => unreachable!(),
+        };
+
+        let good_data = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        let good_signature =
+            ecdsa_p256_sha256_sign_raw(&good_private, &good_data).expect("could not sign");
+        let good_signature2 =
+            ecdsa_p256_sha256_sign_raw(&good_private, &good_data).expect("could not sign");
+
+        // Signing is randomized
+        assert_ne!(good_signature, good_signature2);
+
+        // Good signature verifies
+        assert!(test_ecdsa_p256_sha256_verify_raw(&good_spki, &good_signature, &good_data).is_ok());
+
+        // Wrong data does not verify
+        let other_data = vec![0, 0, 0, 0, 5, 6, 7, 8];
+        assert!(
+            test_ecdsa_p256_sha256_verify_raw(&good_spki, &good_signature, &other_data).is_err()
+        );
+
+        // Wrong signature does not verify
+        let other_signature =
+            ecdsa_p256_sha256_sign_raw(&good_private, &other_data).expect("could not sign");
+        assert!(
+            test_ecdsa_p256_sha256_verify_raw(&good_spki, &other_signature, &good_data).is_err()
+        );
+
+        // Wrong key does not verify
+        let (_, other_public) =
+            COSEKey::generate(COSEAlgorithm::ES256).expect("could not generate a key pair");
+        let other_spki = match other_public.key {
+            COSEKeyType::EC2(ref x) => x.der_spki().expect("could not serialize public key"),
+            _ => unreachable!(),
+        };
+        assert!(
+            test_ecdsa_p256_sha256_verify_raw(&other_spki, &good_signature, &good_data).is_err()
+        );
     }
 }

--- a/src/crypto/nss.rs
+++ b/src/crypto/nss.rs
@@ -87,7 +87,7 @@ fn der_expect_tag_with_short_len(tag: u8, z: &[u8]) -> Result<(&[u8], &[u8])> {
         return Err(CryptoError::MalformedInput);
     }
     let (h, z) = z.split_at(1);
-    if z.len() >= 0x80 || h[0] as usize > z.len() {
+    if h[0] >= 0x80 || h[0] as usize > z.len() {
         return Err(CryptoError::MalformedInput);
     }
     Ok(z.split_at(h[0] as usize))
@@ -582,7 +582,6 @@ pub fn test_ecdsa_p256_sha256_verify_raw(
     nss_gk_api::init();
 
     let signature = decode_der_p256_sig(signature)?;
-    println!("{:?}", data);
     let public = nss_public_key_from_der_spki(public)?;
     unsafe {
         PK11_VerifyWithMechanism(

--- a/src/crypto/nss.rs
+++ b/src/crypto/nss.rs
@@ -1,25 +1,30 @@
 use super::{CryptoError, DER_OID_P256_BYTES};
 use nss_gk_api::p11::{
     PK11Origin, PK11_CreateContextBySymKey, PK11_Decrypt, PK11_DigestFinal, PK11_DigestOp,
-    PK11_Encrypt, PK11_GenerateKeyPairWithOpFlags, PK11_GenerateRandom, PK11_HashBuf,
-    PK11_ImportSymKey, PK11_PubDeriveWithKDF, PrivateKey, PublicKey,
+    PK11_Encrypt, PK11_ExportDERPrivateKeyInfo, PK11_GenerateKeyPairWithOpFlags,
+    PK11_GenerateRandom, PK11_HashBuf, PK11_ImportDERPrivateKeyInfoAndReturnKey, PK11_ImportSymKey,
+    PK11_PubDeriveWithKDF, PK11_SignWithMechanism, PrivateKey, PublicKey,
     SECKEY_DecodeDERSubjectPublicKeyInfo, SECKEY_ExtractPublicKey, SECOidTag, Slot,
-    SubjectPublicKeyInfo, AES_BLOCK_SIZE, PK11_ATTR_SESSION, SHA256_LENGTH,
+    SubjectPublicKeyInfo, AES_BLOCK_SIZE, PK11_ATTR_EXTRACTABLE, PK11_ATTR_INSENSITIVE,
+    PK11_ATTR_SESSION, SHA256_LENGTH,
 };
-use nss_gk_api::{IntoResult, SECItem, SECItemBorrowed, PR_FALSE};
+use nss_gk_api::{IntoResult, SECItem, SECItemBorrowed, ScopedSECItem, PR_FALSE};
 use pkcs11_bindings::{
     CKA_DERIVE, CKA_ENCRYPT, CKA_SIGN, CKD_NULL, CKF_DERIVE, CKM_AES_CBC, CKM_ECDH1_DERIVE,
-    CKM_EC_KEY_PAIR_GEN, CKM_SHA256_HMAC, CKM_SHA512_HMAC,
+    CKM_ECDSA_SHA256, CKM_EC_KEY_PAIR_GEN, CKM_SHA256_HMAC, CKM_SHA512_HMAC,
 };
 use std::convert::TryFrom;
 use std::os::raw::{c_int, c_uint};
 use std::ptr;
 
+const DER_TAG_INTEGER: u8 = 0x02;
+const DER_TAG_SEQUENCE: u8 = 0x30;
+
 #[cfg(test)]
 use super::DER_OID_EC_PUBLIC_KEY_BYTES;
 
 #[cfg(test)]
-use nss_gk_api::p11::PK11_ImportDERPrivateKeyInfoAndReturnKey;
+use nss_gk_api::p11::PK11_VerifyWithMechanism;
 
 impl From<nss_gk_api::Error> for CryptoError {
     fn from(e: nss_gk_api::Error) -> Self {
@@ -28,6 +33,118 @@ impl From<nss_gk_api::Error> for CryptoError {
 }
 
 pub type Result<T> = std::result::Result<T, CryptoError>;
+
+// DER encode a pair of 32 byte unsigned integers as an RFC 3279 Ecdsa-Sig-Value.
+//   Ecdsa-Sig-Value  ::=  SEQUENCE  {
+//        r     INTEGER,
+//        s     INTEGER }.
+fn encode_der_p256_sig(r: &[u8], s: &[u8]) -> Result<Vec<u8>> {
+    if r.len() != 32 || s.len() != 32 {
+        return Err(CryptoError::MalformedInput);
+    }
+    // Each of the inputs is no more than 32 bytes as an unsigned integer. So each is no more than
+    // 33 bytes as a signed integer and no more than 35 bytes with tag and length.  The surrounding
+    // tag and length for the SEQUENCE has length 2, so the output is no more than 72 bytes.
+    let mut out = Vec::with_capacity(72);
+    out.push(DER_TAG_SEQUENCE);
+    out.push(0xaa); // placeholder for final length
+
+    let encode_u256 = |out: &mut Vec<u8>, r: &[u8]| {
+        // trim leading zeros, leaving a single zero if the input is the zero vector.
+        let mut r = r;
+        while r.len() > 1 && r[0] == 0 {
+            r = &r[1..];
+        }
+        out.push(DER_TAG_INTEGER);
+        if r[0] & 0x80 != 0 {
+            // Pad with a zero byte to avoid r being interpreted as a negative value.
+            out.push((r.len() + 1) as u8);
+            out.push(0x00);
+        } else {
+            out.push(r.len() as u8);
+        }
+        out.extend_from_slice(r);
+    };
+
+    encode_u256(&mut out, r);
+    encode_u256(&mut out, s);
+
+    // Write the length of the sequence
+    out[1] = (out.len() - 2) as u8;
+
+    Ok(out)
+}
+
+// Given "tag || len || value || rest" where tag and len are of length one, len is in [0, 127],
+// and value is of length len, returns (value, rest)
+#[cfg(test)]
+fn der_expect_tag_with_short_len(tag: u8, z: &[u8]) -> Result<(&[u8], &[u8])> {
+    if z.is_empty() {
+        return Err(CryptoError::MalformedInput);
+    }
+    let (h, z) = z.split_at(1);
+    if h[0] != tag || z.is_empty() {
+        return Err(CryptoError::MalformedInput);
+    }
+    let (h, z) = z.split_at(1);
+    if z.len() >= 0x80 || h[0] as usize > z.len() {
+        return Err(CryptoError::MalformedInput);
+    }
+    Ok(z.split_at(h[0] as usize))
+}
+
+// Given a DER encoded RFC 3279 Ecdsa-Sig-Value,
+//   Ecdsa-Sig-Value  ::=  SEQUENCE  {
+//        r     INTEGER,
+//        s     INTEGER },
+// with r and s < 2^256, returns a 64 byte array containing
+// r and s encoded as 32 byte zero-padded big endian unsigned
+// integers
+#[cfg(test)]
+fn decode_der_p256_sig(z: &[u8]) -> Result<Vec<u8>> {
+    // Strip the tag and length.
+    let (z, rest) = der_expect_tag_with_short_len(DER_TAG_SEQUENCE, z)?;
+
+    // The input should not have any trailing data.
+    if !rest.is_empty() {
+        return Err(CryptoError::MalformedInput);
+    }
+
+    let read_u256 = |z| -> Result<(&[u8], &[u8])> {
+        let (r, z) = der_expect_tag_with_short_len(DER_TAG_INTEGER, z)?;
+        // We're expecting r < 2^256, so no more than 33 bytes as a signed integer.
+        if r.is_empty() || r.len() > 33 {
+            return Err(CryptoError::MalformedInput);
+        }
+        // If it is 33 bytes the leading byte must be zero.
+        if r.len() == 33 && r[0] != 0 {
+            return Err(CryptoError::MalformedInput);
+        }
+        // Ensure r is no more than 32 bytes.
+        if r.len() == 33 {
+            Ok((&r[1..], z))
+        } else {
+            Ok((r, z))
+        }
+    };
+
+    let (r, z) = read_u256(z)?;
+    let (s, z) = read_u256(z)?;
+
+    // We should have consumed the entire buffer
+    if !z.is_empty() {
+        return Err(CryptoError::MalformedInput);
+    }
+
+    // Left pad each integer with zeros to length 32 and concatenate the results
+    let mut out = vec![0u8; 64];
+    {
+        let (r_out, s_out) = out.split_at_mut(32);
+        r_out[32 - r.len()..].copy_from_slice(r);
+        s_out[32 - s.len()..].copy_from_slice(s);
+    }
+    Ok(out)
+}
 
 fn nss_public_key_from_der_spki(spki: &[u8]) -> Result<PublicKey> {
     // TODO: replace this with an nss-gk-api function
@@ -65,15 +182,7 @@ fn ecdh_nss_raw(client_private: PrivateKey, peer_public: PublicKey) -> Result<Ve
     Ok(ecdh_x_coord_bytes.to_vec())
 }
 
-/// Ephemeral ECDH over P256. Takes a DER SubjectPublicKeyInfo that encodes a public key. Generates
-/// an ephemeral P256 key pair. Returns
-///  1) the x coordinate of the shared point, and
-///  2) the uncompressed SEC 1 encoding of the ephemeral public key.
-pub fn ecdhe_p256_raw(peer_spki: &[u8]) -> Result<(Vec<u8>, Vec<u8>)> {
-    nss_gk_api::init();
-
-    let peer_public = nss_public_key_from_der_spki(peer_spki)?;
-
+fn generate_p256_nss() -> Result<(PrivateKey, PublicKey)> {
     // Hard-coding the P256 OID here is easier than extracting a group name from peer_public and
     // comparing it with P256. We'll fail in `PK11_GenerateKeyPairWithOpFlags` if peer_public is on
     // the wrong curve.
@@ -88,7 +197,7 @@ pub fn ecdhe_p256_raw(peer_spki: &[u8]) -> Result<(Vec<u8>, Vec<u8>)> {
     // `PublicKey::from_ptr` calls here, so I've wrapped them in the same unsafe block as a
     // warning. TODO(jms) Replace this once there is a safer alternative.
     // https://github.com/mozilla/nss-gk-api/issues/1
-    let (client_private, client_public) = unsafe {
+    unsafe {
         let client_private =
             // Type of `param` argument depends on mechanism. For EC keygen it is
             // `SECKEYECParams *` which is a typedef for `SECItem *`.
@@ -97,7 +206,7 @@ pub fn ecdhe_p256_raw(peer_spki: &[u8]) -> Result<(Vec<u8>, Vec<u8>)> {
                 CKM_EC_KEY_PAIR_GEN,
                 oid_ptr.cast(),
                 &mut client_public_ptr,
-                PK11_ATTR_SESSION,
+                PK11_ATTR_EXTRACTABLE | PK11_ATTR_INSENSITIVE | PK11_ATTR_SESSION,
                 CKF_DERIVE,
                 CKF_DERIVE,
                 ptr::null_mut(),
@@ -106,8 +215,74 @@ pub fn ecdhe_p256_raw(peer_spki: &[u8]) -> Result<(Vec<u8>, Vec<u8>)> {
 
         let client_public = PublicKey::from_ptr(client_public_ptr)?;
 
-        (client_private, client_public)
+        Ok((client_private, client_public))
+    }
+}
+
+/// This returns a PKCS#8 ECPrivateKey and an uncompressed SEC1 public key.
+pub fn gen_p256() -> Result<(Vec<u8>, Vec<u8>)> {
+    nss_gk_api::init();
+
+    let (client_private, client_public) = generate_p256_nss()?;
+
+    let pkcs8_priv = unsafe {
+        let pkcs8_priv_item: ScopedSECItem =
+            PK11_ExportDERPrivateKeyInfo(*client_private, ptr::null_mut()).into_result()?;
+        pkcs8_priv_item.into_vec()
     };
+
+    let sec1_pub = client_public.key_data()?;
+
+    Ok((pkcs8_priv, sec1_pub))
+}
+
+pub fn ecdsa_p256_sha256_sign_raw(private: &[u8], data: &[u8]) -> Result<Vec<u8>> {
+    nss_gk_api::init();
+
+    let slot = Slot::internal()?;
+
+    let imported_private: PrivateKey = unsafe {
+        let mut imported_private_ptr = ptr::null_mut();
+        PK11_ImportDERPrivateKeyInfoAndReturnKey(
+            *slot,
+            SECItemBorrowed::wrap(private).as_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            PR_FALSE,
+            PR_FALSE,
+            255, /* todo: expose KU_ flags in nss-gk-api */
+            &mut imported_private_ptr,
+            ptr::null_mut(),
+        );
+        imported_private_ptr.into_result()?
+    };
+
+    let signature_buf = vec![0; 64];
+    unsafe {
+        PK11_SignWithMechanism(
+            *imported_private,
+            CKM_ECDSA_SHA256,
+            ptr::null_mut(),
+            SECItemBorrowed::wrap(&signature_buf).as_mut(),
+            SECItemBorrowed::wrap(data).as_mut(),
+        )
+        .into_result()?;
+    }
+
+    let (r, s) = signature_buf.split_at(32);
+    encode_der_p256_sig(r, s)
+}
+
+/// Ephemeral ECDH over P256. Takes a DER SubjectPublicKeyInfo that encodes a public key. Generates
+/// an ephemeral P256 key pair. Returns
+///  1) the x coordinate of the shared point, and
+///  2) the uncompressed SEC 1 encoding of the ephemeral public key.
+pub fn ecdhe_p256_raw(peer_spki: &[u8]) -> Result<(Vec<u8>, Vec<u8>)> {
+    nss_gk_api::init();
+
+    let peer_public = nss_public_key_from_der_spki(peer_spki)?;
+
+    let (client_private, client_public) = generate_p256_nss()?;
 
     let shared_point = ecdh_nss_raw(client_private, peer_public)?;
 
@@ -300,6 +475,8 @@ pub fn sha256(data: &[u8]) -> Result<Vec<u8>> {
 }
 
 pub fn random_bytes(count: usize) -> Result<Vec<u8>> {
+    nss_gk_api::init();
+
     let count_cint: c_int = match c_int::try_from(count) {
         Ok(c) => c,
         _ => return Err(CryptoError::LibraryFailure),
@@ -394,4 +571,29 @@ pub fn test_ecdh_p256_raw(
     let shared_point = ecdh_nss_raw(client_private, peer_public)?;
 
     Ok(shared_point)
+}
+
+#[cfg(test)]
+pub fn test_ecdsa_p256_sha256_verify_raw(
+    public: &[u8],
+    signature: &[u8],
+    data: &[u8],
+) -> Result<()> {
+    nss_gk_api::init();
+
+    let signature = decode_der_p256_sig(signature)?;
+    println!("{:?}", data);
+    let public = nss_public_key_from_der_spki(public)?;
+    unsafe {
+        PK11_VerifyWithMechanism(
+            *public,
+            CKM_ECDSA_SHA256,
+            ptr::null_mut(),
+            SECItemBorrowed::wrap(&signature).as_mut(),
+            SECItemBorrowed::wrap(data).as_mut(),
+            ptr::null_mut(),
+        )
+        .into_result()?
+    }
+    Ok(())
 }

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -172,6 +172,7 @@ pub fn ecdsa_p256_sha256_sign_raw(_private: &[u8], _data: &[u8]) -> Result<Vec<u
     unimplemented!()
 }
 
+#[allow(dead_code)]
 #[cfg(test)]
 pub fn test_ecdsa_p256_sha256_verify_raw(
     _public: &[u8],

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -163,3 +163,20 @@ pub fn test_ecdh_p256_raw(
 
     Ok(shared_point)
 }
+
+pub fn gen_p256() -> Result<(Vec<u8>, Vec<u8>)> {
+    unimplemented!()
+}
+
+pub fn ecdsa_p256_sha256_sign_raw(_private: &[u8], _data: &[u8]) -> Result<Vec<u8>> {
+    unimplemented!()
+}
+
+#[cfg(test)]
+pub fn test_ecdsa_p256_sha256_verify_raw(
+    _public: &[u8],
+    _signature: &[u8],
+    _data: &[u8],
+) -> Result<()> {
+    unimplemented!()
+}


### PR DESCRIPTION
This adds `crypto::backend` functions for generating P256 keys and signing with ECDSA P256 SHA256.

The "Add Credential" function in the Virtual Authenticator API (https://w3c.github.io/webauthn/#sctn-automation-add-credential) provides the private key as an RFC 5958 `PrivateKeyInfo`. I've made `ecdsa_p256_sha256_sign_raw` a public function within the crypto module since it already acts on `PrivateKeyInfo`s. If we start signing outside of tests, then we'll want a richer type for wrapping private keys. But we'll probably use `EncryptedPrivateKeyInfo` instead, so I'm going to defer locking in those details.

Depends on #278 and https://github.com/mozilla/nss-gk-api/pull/8.