### PR TITLE
Ignore HMAC Secret extension if not supported

### DIFF
--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -311,15 +311,6 @@ pub fn register<Dev: FidoDevice>(
                 return false;
             }
         };
-        // Check if extensions have been requested that are not supported by the device
-        if let Some(true) = args.extensions.hmac_secret {
-            if !info.supports_hmac_secret() {
-                callback.call(Err(AuthenticatorError::UnsupportedOption(
-                    UnsupportedOption::HmacSecret,
-                )));
-                return false;
-            }
-        }
 
         // Set options based on the arguments and the device info.
         // The user verification option will be set in `determine_puap_if_needed`.
@@ -494,22 +485,7 @@ pub fn sign<Dev: FidoDevice>(
     callback: StateCallback<crate::Result<crate::SignResult>>,
     alive: &dyn Fn() -> bool,
 ) -> bool {
-    if dev.get_protocol() == FidoProtocol::CTAP2 {
-        let info = match dev.get_authenticator_info() {
-            Some(info) => info,
-            None => {
-                callback.call(Err(HIDError::DeviceNotInitialized.into()));
-                return false;
-            }
-        };
-        // Check if extensions have been requested that are not supported by the device
-        if args.extensions.hmac_secret.is_some() && !info.supports_hmac_secret() {
-            callback.call(Err(AuthenticatorError::UnsupportedOption(
-                UnsupportedOption::HmacSecret,
-            )));
-            return false;
-        }
-    } else {
+    if dev.get_protocol() == FidoProtocol::CTAP1 {
         // Check that the request can be processed by a CTAP1 device.
         // See CTAP 2.1 Section 10.3. Some additional checks are performed in
         // GetAssertion::RequestCtap1

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,7 +14,6 @@ use std::sync::mpsc;
 #[derive(Debug)]
 pub enum UnsupportedOption {
     EmptyAllowList,
-    HmacSecret,
     MaxPinLength,
     PubCredParams,
     ResidentKey,


### PR DESCRIPTION

[Make Credentials 15.1](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#op-makecred-step-extensions) and [Get Assertion 10.1](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#ref-for-getassert-extensions) say
> Process any [extensions](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#makecred-extensions) that this authenticator supports, ignoring any that it does not support.

So we should ignore the unsupported extension, not error out.
