### PR TITLE
Pre-flight and AppID improvements

### DIFF
--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -237,7 +237,7 @@ fn main() {
     let ctap_args = SignArgs {
         client_data_hash: chall_bytes,
         origin: format!("https://{rp_id}"),
-        relying_party_id: rp_id.clone(),
+        relying_party_id: rp_id,
         allow_list,
         user_verification_req: UserVerificationRequirement::Preferred,
         user_presence_req: true,

--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -10,13 +10,13 @@ use authenticator::{
     crypto::COSEAlgorithm,
     ctap2::server::{
         PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
-        ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
+        RelyingPartyWrapper, ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
     },
     statecallback::StateCallback,
     Pin, StatusPinUv, StatusUpdate,
 };
 use getopts::Options;
-use sha2::{Digest, Sha256};
+use rand::{thread_rng, RngCore};
 use std::sync::mpsc::{channel, RecvError};
 use std::{env, thread};
 
@@ -31,6 +31,9 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     let program = args[0].clone();
 
+    let rp_id = "example.com".to_string();
+    let app_id = "https://fido.example.com/myApp".to_string();
+
     let mut opts = Options::new();
     opts.optflag("x", "no-u2f-usb-hid", "do not enable u2f-usb-hid platforms");
     opts.optflag("h", "help", "print this help menu").optopt(
@@ -38,6 +41,11 @@ fn main() {
         "timeout",
         "timeout in seconds",
         "SEC",
+    );
+    opts.optflag(
+        "a",
+        "app_id",
+        &format!("Using App ID {app_id} from origin 'https://{rp_id}'"),
     );
     opts.optflag("s", "hmac_secret", "With hmac-secret");
     opts.optflag("h", "help", "print this help menu");
@@ -73,14 +81,8 @@ fn main() {
     };
 
     println!("Asking a security key to register now...");
-    let challenge_str = format!(
-        "{}{}",
-        r#"{"challenge": "1vQ9mxionq0ngCnjD-wTsv1zUSrGRtFqG2xP09SbZ70","#,
-        r#" "version": "U2F_V2", "appId": "http://example.com"}"#
-    );
-    let mut challenge = Sha256::new();
-    challenge.update(challenge_str.as_bytes());
-    let chall_bytes: [u8; 32] = challenge.finalize().into();
+    let mut chall_bytes = [0u8; 32];
+    thread_rng().fill_bytes(&mut chall_bytes);
 
     let (status_tx, status_rx) = channel::<StatusUpdate>();
     thread::spawn(move || loop {
@@ -146,14 +148,19 @@ fn main() {
         name: Some("A. User".to_string()),
         display_name: None,
     };
-    let origin = "https://example.com".to_string();
+    // If we're testing AppID support, then register with an RP ID that isn't valid for the origin.
+    let relying_party = RelyingParty {
+        id: if matches.opt_present("app_id") {
+            app_id.clone()
+        } else {
+            rp_id.clone()
+        },
+        name: None,
+    };
     let ctap_args = RegisterArgs {
         client_data_hash: chall_bytes,
-        relying_party: RelyingParty {
-            id: "example.com".to_string(),
-            name: None,
-        },
-        origin: origin.clone(),
+        relying_party,
+        origin: format!("https://{rp_id}"),
         user,
         pub_cred_params: vec![
             PublicKeyCredentialParameters {
@@ -226,10 +233,11 @@ fn main() {
         allow_list = Vec::new();
     }
 
+    let alternate_rp_id = matches.opt_present("app_id").then(|| app_id.clone());
     let ctap_args = SignArgs {
         client_data_hash: chall_bytes,
-        origin,
-        relying_party_id: "example.com".to_string(),
+        origin: format!("https://{rp_id}"),
+        relying_party_id: rp_id.clone(),
         allow_list,
         user_verification_req: UserVerificationRequirement::Preferred,
         user_presence_req: true,
@@ -248,7 +256,7 @@ fn main() {
             },
         },
         pin: None,
-        alternate_rp_id: None,
+        alternate_rp_id: alternate_rp_id.clone(),
         use_ctap1_fallback: fallback,
     };
 
@@ -270,6 +278,13 @@ fn main() {
         match sign_result {
             Ok(assertion_object) => {
                 println!("Assertion Object: {assertion_object:?}");
+                if let Some(alt_rp_id) = alternate_rp_id {
+                    assert_eq!(
+                        assertion_object.0[0].auth_data.rp_id_hash,
+                        RelyingPartyWrapper::from(alt_rp_id.as_str()).hash()
+                    );
+                    println!("Used AppID");
+                }
                 println!("Done.");
                 break;
             }

--- a/examples/interactive_management.rs
+++ b/examples/interactive_management.rs
@@ -472,7 +472,7 @@ fn ask_user_bio_options(
                     .expect("error: unable to read user input");
                 let name = input.trim().to_string();
                 tx.send(InteractiveRequest::BioEnrollment(
-                    BioEnrollmentCmd::ChangeName(chosen_id, name.clone()),
+                    BioEnrollmentCmd::ChangeName(chosen_id, name),
                     puat,
                 ))
                 .expect("Failed to send GetEnrollments request.");

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -1155,7 +1155,7 @@ pub mod test {
 
         // Sending first GetAssertion with first allow_list-entry, that will return an error
         let mut msg = cid.to_vec();
-        msg.extend(vec![HIDCmd::Cbor.into(), 0x00, 0x94]);
+        msg.extend(vec![HIDCmd::Cbor.into(), 0x00, 0x90]);
         msg.extend(vec![0x2]); // u2f command
         msg.extend(vec![
             0xa4, // map(4)
@@ -1191,10 +1191,7 @@ pub mod test {
             0x6a, // text(10)
             0x70, 0x75, 0x62, 0x6C, 0x69, 0x63, 0x2D, 0x6B, 0x65, 0x79, // public-key
             0x5,  // options
-            0xa2, // map(2)
-            0x62, // text(2)
-            0x75, 0x76, // uv
-            0xf4, // false
+            0xa1, // map(1)
             0x62, // text(2)
             0x75, 0x70, // up
             0xf4, // false
@@ -1210,7 +1207,7 @@ pub mod test {
 
         // Sending second GetAssertion with first allow_list-entry, that will return a success
         let mut msg = cid.to_vec();
-        msg.extend(vec![HIDCmd::Cbor.into(), 0x00, 0x94]);
+        msg.extend(vec![HIDCmd::Cbor.into(), 0x00, 0x90]);
         msg.extend(vec![0x2]); // u2f command
         msg.extend(vec![
             0xa4, // map(4)
@@ -1246,10 +1243,7 @@ pub mod test {
             0x6a, // text(10)
             0x70, 0x75, 0x62, 0x6C, 0x69, 0x63, 0x2D, 0x6B, 0x65, 0x79, // public-key
             0x5,  // options
-            0xa2, // map(2)
-            0x62, // text(2)
-            0x75, 0x76, // uv
-            0xf4, // false
+            0xa1, // map(1)
             0x62, // text(2)
             0x75, 0x70, // up
             0xf4, // false

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -168,9 +168,6 @@ pub struct GetAssertion {
     pub extensions: GetAssertionExtensions,
     pub options: GetAssertionOptions,
     pub pin_uv_auth_param: Option<PinUvAuthParam>,
-
-    // This is used to implement the FIDO AppID extension.
-    pub alternate_rp_id: Option<String>,
 }
 
 impl GetAssertion {
@@ -180,7 +177,6 @@ impl GetAssertion {
         allow_list: Vec<PublicKeyCredentialDescriptor>,
         options: GetAssertionOptions,
         extensions: GetAssertionExtensions,
-        alternate_rp_id: Option<String>,
     ) -> Self {
         Self {
             client_data_hash,
@@ -189,7 +185,6 @@ impl GetAssertion {
             extensions,
             options,
             pin_uv_auth_param: None,
-            alternate_rp_id,
         }
     }
 }
@@ -636,7 +631,6 @@ pub mod test {
                 user_verification: None,
             },
             Default::default(),
-            None,
         );
         let mut device = Device::new("commands/get_assertion").unwrap();
         assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
@@ -835,7 +829,6 @@ pub mod test {
                 user_verification: None,
             },
             Default::default(),
-            None,
         );
         let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
                                                                          // channel id
@@ -925,7 +918,6 @@ pub mod test {
                 user_verification: None,
             },
             Default::default(),
-            None,
         );
 
         let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
@@ -1106,7 +1098,6 @@ pub mod test {
                 user_verification: None,
             },
             Default::default(),
-            None,
         );
         let mut device = Device::new("commands/get_assertion").unwrap();
         assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);

--- a/src/ctap2/preflight.rs
+++ b/src/ctap2/preflight.rs
@@ -159,7 +159,6 @@ pub(crate) fn do_credential_list_filtering_ctap2<Dev: FidoDevice>(
                 user_presence: Some(false),
             },
             GetAssertionExtensions::default(),
-            None,
         );
         silent_assert.set_pin_uv_auth_param(pin_uv_auth_token.clone())?;
         let res = dev.send_msg(&silent_assert);

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -60,6 +60,15 @@ pub enum RelyingPartyWrapper {
     Hash(RpIdHash),
 }
 
+impl From<&str> for RelyingPartyWrapper {
+    fn from(rp_id: &str) -> Self {
+        Self::Data(RelyingParty {
+            id: rp_id.to_string(),
+            name: None,
+        })
+    }
+}
+
 impl RelyingPartyWrapper {
     pub fn hash(&self) -> RpIdHash {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@ pub use ctap2::commands::client_pin::{Pin, PinError};
 pub use ctap2::commands::credential_management::CredentialManagementResult;
 pub use ctap2::commands::get_assertion::{Assertion, GetAssertionResult};
 pub use ctap2::commands::get_info::AuthenticatorInfo;
-use serde::Serialize;
 pub use ctap2::commands::make_credentials::MakeCredentialsResult;
+use serde::Serialize;
 pub use statemachine::StateMachine;
 pub use status_update::{
     BioEnrollmentCmd, CredManagementCmd, InteractiveRequest, InteractiveUpdate, StatusPinUv,

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -308,7 +308,7 @@ impl StateMachine {
                     &ClientDataHash(args.client_data_hash),
                 );
                 let mut auto_select = !silent_creds.is_empty();
-                if !auto_select && !args.allow_list.is_empty() {
+                if silent_creds.is_empty() && !args.allow_list.is_empty() {
                     // Check if we have (U2F / server-side) credentials bound to the alternate RP ID.
                     if let Some(ref alt_rp_id) = args.alternate_rp_id {
                         let silent_creds = silently_discover_credentials(

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -5,6 +5,7 @@
 use crate::authenticatorservice::{RegisterArgs, SignArgs};
 use crate::consts::PARAMETER_SIZE;
 
+use crate::ctap2;
 use crate::ctap2::client_data::ClientDataHash;
 use crate::ctap2::commands::client_pin::Pin;
 use crate::ctap2::commands::get_assertion::GetAssertionResult;
@@ -22,7 +23,6 @@ use crate::transport::device_selector::{
 use crate::transport::platform::transaction::Transaction;
 use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
 use crate::u2fprotocol::{u2f_init_device, u2f_is_keyhandle_valid, u2f_register, u2f_sign};
-use crate::ctap2;
 use crate::{
     AuthenticatorTransports, InteractiveRequest, KeyHandle, ManageResult, RegisterFlags, SignFlags,
 };
@@ -69,19 +69,16 @@ impl StateMachine {
         Default::default()
     }
 
-    fn init_and_select(
+    fn init_device(
         info: DeviceBuildParameters,
         selector: &Sender<DeviceSelectorEvent>,
-        status: &Sender<crate::StatusUpdate>,
-        ctap2_only: bool,
-        keep_alive: &dyn Fn() -> bool,
     ) -> Option<Device> {
         // Create a new device.
         let mut dev = match Device::new(info) {
             Ok(dev) => dev,
             Err((e, id)) => {
                 info!("error happened with device: {}", e);
-                selector.send(DeviceSelectorEvent::NotAToken(id)).ok()?;
+                let _ = selector.send(DeviceSelectorEvent::NotAToken(id));
                 return None;
             }
         };
@@ -89,20 +86,29 @@ impl StateMachine {
         // Try initializing it.
         if let Err(e) = dev.init() {
             warn!("error while initializing device: {}", e);
-            selector.send(DeviceSelectorEvent::NotAToken(dev.id())).ok();
+            let _ = selector.send(DeviceSelectorEvent::NotAToken(dev.id()));
             return None;
         }
 
-        if ctap2_only && dev.get_protocol() != FidoProtocol::CTAP2 {
-            info!("Device does not support CTAP2");
-            selector.send(DeviceSelectorEvent::NotAToken(dev.id())).ok();
-            return None;
-        }
+        Some(dev)
+    }
 
+    fn wait_for_device_selector(
+        dev: &mut Device,
+        selector: &Sender<DeviceSelectorEvent>,
+        status: &Sender<crate::StatusUpdate>,
+        auto_select: bool,
+        keep_alive: &dyn Fn() -> bool,
+    ) -> bool {
         let (tx, rx) = channel();
-        selector
+        if selector
             .send(DeviceSelectorEvent::ImAToken((dev.id(), tx)))
-            .ok()?;
+            .is_err()
+        {
+            // If we fail to register with the device selector, then we're not going
+            // to be selected.
+            return false;
+        }
 
         // We can be cancelled from the user (through keep_alive()) or from the device selector
         // (through a DeviceCommand::Cancel on rx).  We'll combine those signals into a single
@@ -111,42 +117,49 @@ impl StateMachine {
 
         // Blocking recv. DeviceSelector will tell us what to do
         match rx.recv() {
+            Ok(DeviceCommand::Blink) if auto_select => {
+                // The caller knows it wants to select this device. Now that we've received
+                // a blink command from the device selector, we can request to be selected.
+                // We may be racing several devices here.
+                selector
+                    .send(DeviceSelectorEvent::SelectedToken(dev.id()))
+                    .is_ok()
+            }
             Ok(DeviceCommand::Blink) => {
-                // Inform the user that there are multiple devices available.
-                // NOTE: We'll send this once per device, so the recipient should be prepared
-                // to receive this message multiple times.
+                // The caller wants the user to choose a device. Send a status update and blink
+                // this device. NOTE: We send one status update per device, so the recipient should be
+                // prepared to receive the message multiple times.
                 send_status(status, crate::StatusUpdate::SelectDeviceNotice);
                 match dev.block_and_blink(&keep_blinking) {
                     BlinkResult::DeviceSelected => {
                         // User selected us. Let DeviceSelector know, so it can cancel all other
-                        // outstanding open blink-requests.
+                        // outstanding open blink-requests. If we fail to send the SelectedToken
+                        // message to the device selector, then don't consider this token as having
+                        // been selected.
                         selector
                             .send(DeviceSelectorEvent::SelectedToken(dev.id()))
-                            .ok()?;
+                            .is_ok()
                     }
                     BlinkResult::Cancelled => {
                         info!("Device {:?} was not selected", dev.id());
-                        return None;
+                        false
                     }
                 }
             }
             Ok(DeviceCommand::Cancel) => {
                 info!("Device {:?} was not selected", dev.id());
-                return None;
+                false
             }
             Ok(DeviceCommand::Removed) => {
                 info!("Device {:?} was removed", dev.id());
-                return None;
+                false
             }
-            Ok(DeviceCommand::Continue) => {
-                // Just continue
-            }
+            Ok(DeviceCommand::Continue) => true,
             Err(_) => {
                 warn!("Error when trying to receive messages from DeviceSelector! Exiting.");
-                return None;
+                false
             }
         }
-        Some(dev)
     }
 
     pub fn register(
@@ -198,11 +211,12 @@ impl StateMachine {
             cbc.clone(),
             status,
             move |info, selector, status, alive| {
-                let mut dev = match Self::init_and_select(info, &selector, &status, false, alive) {
-                    None => {
-                        return;
-                    }
+                let mut dev = match Self::init_device(info, &selector) {
                     Some(dev) => dev,
+                    None => return,
+                };
+                if !Self::wait_for_device_selector(&mut dev, &selector, &status, false, alive) {
+                    return;
                 };
 
                 info!("Device {:?} continues with the register process", dev.id());
@@ -275,11 +289,19 @@ impl StateMachine {
             callback.clone(),
             status,
             move |info, selector, status, alive| {
-                let mut dev = match Self::init_and_select(info, &selector, &status, false, alive) {
-                    None => {
-                        return;
-                    }
+                let mut dev = match Self::init_device(info, &selector) {
                     Some(dev) => dev,
+                    None => return,
+                };
+
+                if !Self::wait_for_device_selector(
+                    &mut dev,
+                    &selector,
+                    &status,
+                    auto_select,
+                    alive,
+                ) {
+                    return;
                 };
 
                 info!("Device {:?} continues with the signing process", dev.id());
@@ -319,11 +341,19 @@ impl StateMachine {
             callback.clone(),
             status,
             move |info, selector, status, alive| {
-                let mut dev = match Self::init_and_select(info, &selector, &status, true, alive) {
-                    None => {
-                        return;
-                    }
+                let mut dev = match Self::init_device(info, &selector) {
                     Some(dev) => dev,
+                    None => return,
+                };
+
+                if dev.get_protocol() != FidoProtocol::CTAP2 {
+                    info!("Device does not support CTAP2");
+                    let _ = selector.send(DeviceSelectorEvent::NotAToken(dev.id()));
+                    return;
+                }
+
+                if !Self::wait_for_device_selector(&mut dev, &selector, &status, false, alive) {
+                    return;
                 };
                 ctap2::reset_helper(&mut dev, selector, status, callback.clone(), alive);
             },
@@ -349,11 +379,19 @@ impl StateMachine {
             callback.clone(),
             status,
             move |info, selector, status, alive| {
-                let mut dev = match Self::init_and_select(info, &selector, &status, true, alive) {
-                    None => {
-                        return;
-                    }
+                let mut dev = match Self::init_device(info, &selector) {
                     Some(dev) => dev,
+                    None => return,
+                };
+
+                if dev.get_protocol() != FidoProtocol::CTAP2 {
+                    info!("Device does not support CTAP2");
+                    let _ = selector.send(DeviceSelectorEvent::NotAToken(dev.id()));
+                    return;
+                }
+
+                if !Self::wait_for_device_selector(&mut dev, &selector, &status, false, alive) {
+                    return;
                 };
 
                 ctap2::set_or_change_pin_helper(
@@ -607,11 +645,19 @@ impl StateMachine {
             callback.clone(),
             status,
             move |info, selector, status, alive| {
-                let mut dev = match Self::init_and_select(info, &selector, &status, true, alive) {
-                    None => {
-                        return;
-                    }
+                let mut dev = match Self::init_device(info, &selector) {
                     Some(dev) => dev,
+                    None => return,
+                };
+
+                if dev.get_protocol() != FidoProtocol::CTAP2 {
+                    info!("Device does not support CTAP2");
+                    let _ = selector.send(DeviceSelectorEvent::NotAToken(dev.id()));
+                    return;
+                }
+
+                if !Self::wait_for_device_selector(&mut dev, &selector, &status, false, alive) {
+                    return;
                 };
 
                 info!("Device {:?} selected for interactive management.", dev.id());


### PR DESCRIPTION
The first patch splits `StateMachine::init_and_select` into distinct `init` and `select` stages. It adds an `auto_select` hint to the `select` stage that can be used to skip device selection when the caller can determine that a particular device is suitable for the request.

The second patch uses the `auto_select` hint when we find acceptable credentials on a device through silent discovery. This resolves [Bug 1451111](https://bugzilla.mozilla.org/show_bug.cgi?id=1451111)

The third patch uses silent discovery to determine if there are acceptable (U2F) credentials on the device that require the use of the AppID extension. This resolves #269 and [Bug 1846836](https://bugzilla.mozilla.org/show_bug.cgi?id=1846836).

I also added a `-a` flag to the ctap2 example which causes it to use an alternate RP ID. (This is added in the second patch but is used to test the third patch's behavior).