### PR TITLE
Return the correct CredentialExcluded error when handling CTAP1 devices

### DIFF
--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -480,11 +480,7 @@ pub fn register<Dev: FidoDevice>(
                 send_status(&status, crate::StatusUpdate::PresenceRequired);
                 let msg = dummy_make_credentials_cmd();
                 let _ = dev.send_msg_cancellable(&msg, alive); // Ignore answer, return "CredentialExcluded"
-                callback.call(Err(HIDError::Command(CommandError::StatusCode(
-                    StatusCode::CredentialExcluded,
-                    None,
-                ))
-                .into()));
+                callback.call(Err(AuthenticatorError::CredentialExcluded));
                 return false;
             }
         }


### PR DESCRIPTION
The `CredentialExcluded` error is one of the few that are turned into an `InvalidState` DOM error instead of a `NotAllowed` DOM error, so consumers of this library need an easy way to recognize it. We have `AuthenticatorError::CredentialExcluded` for this purpose, but we were returning `HIDError::Command(CommandError::StatusCode(StatusCode::CredentialExcluded, None))` when we found an excluded credential on a CTAP1 device.