### PR TITLE
Some fixes for interactive management

### DIFF
--- a/examples/interactive_management.rs
+++ b/examples/interactive_management.rs
@@ -533,7 +533,7 @@ fn handle_bio_enrollments(
             ))
             .expect("Failed to send GetEnrollments request.");
         }
-        Some(BioEnrollmentResult::DeleteSucess(info)) => {
+        Some(BioEnrollmentResult::DeleteSuccess(info)) => {
             *auth_info = Some(info.clone());
             if BioOperation::parse_possible_operations(&info).contains(&BioOperation::List) {
                 tx.send(InteractiveRequest::BioEnrollment(

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -358,8 +358,7 @@ impl SharedSecret {
 pub struct PinUvAuthToken {
     pub pin_protocol: PinUvAuthProtocol,
     pin_token: Vec<u8>,
-    #[allow(dead_code)] // Not yet used
-    permissions: PinUvAuthTokenPermission,
+    pub permissions: PinUvAuthTokenPermission,
 }
 
 impl PinUvAuthToken {

--- a/src/ctap2/commands/bio_enrollment.rs
+++ b/src/ctap2/commands/bio_enrollment.rs
@@ -650,7 +650,7 @@ pub struct FingerprintSensorInfo {
 #[derive(Debug, Serialize)]
 pub enum BioEnrollmentResult {
     EnrollmentList(Vec<EnrollmentInfo>),
-    DeleteSucess(AuthenticatorInfo),
+    DeleteSuccess(AuthenticatorInfo),
     UpdateSuccess,
     AddSuccess(AuthenticatorInfo),
     FingerprintSensorInfo(FingerprintSensorInfo),

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -987,11 +987,19 @@ pub(crate) fn bio_enrollment(
                         return true;
                     }
                     BioEnrollmentCommand::SetFriendlyName(_) => {
+                        let res = match command {
+                            BioEnrollmentCmd::StartNewEnrollment(..) => {
+                                let auth_info =
+                                    unwrap_option!(dev.refresh_authenticator_info(), callback);
+                                BioEnrollmentResult::AddSuccess(auth_info.clone())
+                            }
+                            _ => BioEnrollmentResult::UpdateSuccess,
+                        };
                         send_status(
                             &status,
                             StatusUpdate::InteractiveManagement(
                                 InteractiveUpdate::BioEnrollmentUpdate((
-                                    BioEnrollmentResult::UpdateSuccess,
+                                    res,
                                     Some(pin_uv_auth_result),
                                 )),
                             ),

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -866,7 +866,8 @@ pub(crate) fn bio_enrollment(
         Some(PinUvAuthResult::SuccessGetPinToken(t))
         | Some(PinUvAuthResult::SuccessGetPinUvAuthTokenUsingUvWithPermissions(t))
         | Some(PinUvAuthResult::SuccessGetPinUvAuthTokenUsingPinWithPermissions(t))
-            if t.permissions == PinUvAuthTokenPermission::BioEnrollment =>
+            if t.permissions
+                .contains(PinUvAuthTokenPermission::BioEnrollment) =>
         {
             skip_puap = true;
             cached_puat = true;

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -974,7 +974,7 @@ pub(crate) fn bio_enrollment(
                             &status,
                             StatusUpdate::InteractiveManagement(
                                 InteractiveUpdate::BioEnrollmentUpdate((
-                                    BioEnrollmentResult::DeleteSucess(auth_info.clone()),
+                                    BioEnrollmentResult::DeleteSuccess(auth_info.clone()),
                                     Some(pin_uv_auth_result),
                                 )),
                             ),

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -302,7 +302,7 @@ impl<'de> Deserialize<'de> for PublicKeyCredentialDescriptor {
             }
         }
 
-        deserializer.deserialize_bytes(PublicKeyCredentialDescriptorVisitor)
+        deserializer.deserialize_any(PublicKeyCredentialDescriptorVisitor)
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,6 +11,7 @@ macro_rules! try_or {
         match $val {
             Ok(v) => v,
             Err(e) => {
+                #[allow(clippy::redundant_closure_call)]
                 return $or(e);
             }
         }


### PR DESCRIPTION
1. Fix typo
2. Allow deserializing PublicKeyCredentialDescriptor from JSON and CBOR, instead of only CBOR.
3. Automatically clear cached PUAT and try getting a new one (e.g.: when doing a few BioEnrollment-operations and then do CredentialManagement-operations).