### PR TITLE
Add credProps, minPinLength, credProtect extensions and rework appID and hmac-secret

### DIFF
--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -180,6 +180,7 @@ fn main() {
         resident_key_req: ResidentKeyRequirement::Discouraged,
         extensions: AuthenticationExtensionsClientInputs {
             cred_props: Some(true),
+            min_pin_length: Some(true),
             ..Default::default()
         },
         pin: None,

--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -176,12 +176,8 @@ fn main() {
         }],
         user_verification_req: UserVerificationRequirement::Preferred,
         resident_key_req: ResidentKeyRequirement::Discouraged,
-        extensions: MakeCredentialsExtensions {
-            hmac_secret: if matches.opt_present("hmac_secret") {
-                Some(true)
-            } else {
-                None
-            },
+        extensions: AuthenticationExtensionsClientInputs {
+            cred_props: Some(true),
             ..Default::default()
         },
         pin: None,

--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -178,6 +178,7 @@ fn main() {
         resident_key_req: ResidentKeyRequirement::Discouraged,
         extensions: AuthenticationExtensionsClientInputs {
             cred_props: Some(true),
+            hmac_create_secret: Some(matches.opt_present("hmac_secret")),
             min_pin_length: Some(true),
             credential_protection_policy: Some(
                 CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIDList,

--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -8,9 +8,9 @@ use authenticator::{
     },
     crypto::COSEAlgorithm,
     ctap2::server::{
-        AuthenticationExtensionsClientInputs,
+        AuthenticationExtensionsClientInputs, CredentialProtectionPolicy,
         PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
-        RelyingPartyWrapper, ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
+        ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
     },
     statecallback::StateCallback,
     Pin, StatusPinUv, StatusUpdate,
@@ -181,6 +181,9 @@ fn main() {
         extensions: AuthenticationExtensionsClientInputs {
             cred_props: Some(true),
             min_pin_length: Some(true),
+            credential_protection_policy: Some(
+                CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIDList,
+            ),
             ..Default::default()
         },
         pin: None,

--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -3,9 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use authenticator::{
-    authenticatorservice::{
-        AuthenticatorService, RegisterArgs, SignArgs,
-    },
+    authenticatorservice::{AuthenticatorService, RegisterArgs, SignArgs},
     crypto::COSEAlgorithm,
     ctap2::server::{
         AuthenticationExtensionsClientInputs, CredentialProtectionPolicy,

--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -297,7 +297,6 @@ fn main() {
         user_presence_req: true,
         extensions: Default::default(),
         pin: None,
-        alternate_rp_id: None,
         use_ctap1_fallback: false,
     };
 
@@ -324,7 +323,7 @@ fn main() {
                 println!(
                     "{:?}",
                     assertion_object
-                        .0
+                        .assertions
                         .iter()
                         .map(|x| x.user.clone().unwrap().name.unwrap()) // Unwrapping here, as these shouldn't fail
                         .collect::<Vec<_>>()

--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -6,8 +6,9 @@ use authenticator::{
     authenticatorservice::{AuthenticatorService, RegisterArgs, SignArgs},
     crypto::COSEAlgorithm,
     ctap2::server::{
-        PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
-        ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
+        AuthenticationExtensionsClientInputs, PublicKeyCredentialDescriptor,
+        PublicKeyCredentialParameters, RelyingParty, ResidentKeyRequirement, Transport, User,
+        UserVerificationRequirement,
     },
     statecallback::StateCallback,
     Pin, StatusPinUv, StatusUpdate,
@@ -132,7 +133,10 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
         }],
         user_verification_req: UserVerificationRequirement::Required,
         resident_key_req: ResidentKeyRequirement::Required,
-        extensions: Default::default(),
+        extensions: AuthenticationExtensionsClientInputs {
+            cred_props: Some(true),
+            ..Default::default()
+        },
         pin: None,
         use_ctap1_fallback: false,
     };

--- a/examples/reset.rs
+++ b/examples/reset.rs
@@ -41,8 +41,8 @@ fn main() {
         return;
     }
 
-    let mut manager = AuthenticatorService::new()
-        .expect("The auth service should initialize safely");
+    let mut manager =
+        AuthenticatorService::new().expect("The auth service should initialize safely");
     manager.add_u2f_usb_hid_platform_transports();
 
     let timeout_ms = match matches.opt_get_default::<u64>("timeout", 25) {

--- a/examples/set_pin.rs
+++ b/examples/set_pin.rs
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use authenticator::{
-    authenticatorservice::AuthenticatorService,
-    statecallback::StateCallback,
-    Pin, StatusPinUv, StatusUpdate,
+    authenticatorservice::AuthenticatorService, statecallback::StateCallback, Pin, StatusPinUv,
+    StatusUpdate,
 };
 use getopts::Options;
 use std::sync::mpsc::{channel, RecvError};
@@ -39,8 +38,8 @@ fn main() {
         return;
     }
 
-    let mut manager = AuthenticatorService::new()
-        .expect("The auth service should initialize safely");
+    let mut manager =
+        AuthenticatorService::new().expect("The auth service should initialize safely");
     manager.add_u2f_usb_hid_platform_transports();
 
     let timeout_ms = match matches.opt_get_default::<u64>("timeout", 25) {

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -222,7 +222,6 @@ fn main() {
         allow_list: vec![],
         extensions: Default::default(),
         pin: None,
-        alternate_rp_id: None,
         use_ctap1_fallback: false,
         user_verification_req: UserVerificationRequirement::Preferred,
         user_presence_req: true,

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -183,7 +183,13 @@ fn main() {
             Ok(a) => {
                 println!("Ok!");
                 println!("Registering again with the key_handle we just got back. This should result in a 'already registered' error.");
-                let key_handle = a.att_obj.auth_data.credential_data.unwrap().credential_id.clone();
+                let key_handle = a
+                    .att_obj
+                    .auth_data
+                    .credential_data
+                    .unwrap()
+                    .credential_id
+                    .clone();
                 let pub_key = PublicKeyCredentialDescriptor {
                     id: key_handle,
                     transports: vec![Transport::USB],

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use authenticator::{
-    authenticatorservice::{AuthenticatorService, GetAssertionExtensions, RegisterArgs, SignArgs},
+    authenticatorservice::{AuthenticatorService, RegisterArgs, SignArgs},
     crypto::COSEAlgorithm,
     ctap2::commands::StatusCode,
     ctap2::server::{
@@ -220,7 +220,7 @@ fn main() {
         origin,
         relying_party_id: "example.com".to_string(),
         allow_list: vec![],
-        extensions: GetAssertionExtensions::default(),
+        extensions: Default::default(),
         pin: None,
         alternate_rp_id: None,
         use_ctap1_fallback: false,

--- a/src/authenticatorservice.rs
+++ b/src/authenticatorservice.rs
@@ -4,8 +4,9 @@
 
 use crate::ctap2::commands::client_pin::Pin;
 use crate::ctap2::server::{
-    AuthenticationExtensionsClientInputs, PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
-    ResidentKeyRequirement, User, UserVerificationRequirement,
+    AuthenticationExtensionsClientInputs, PublicKeyCredentialDescriptor,
+    PublicKeyCredentialParameters, RelyingParty, ResidentKeyRequirement, User,
+    UserVerificationRequirement,
 };
 use crate::errors::*;
 use crate::manager::Manager;

--- a/src/authenticatorservice.rs
+++ b/src/authenticatorservice.rs
@@ -3,10 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::ctap2::commands::client_pin::Pin;
-pub use crate::ctap2::commands::get_assertion::{GetAssertionExtensions, HmacSecretExtension};
-pub use crate::ctap2::commands::make_credentials::MakeCredentialsExtensions;
 use crate::ctap2::server::{
-    PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
+    AuthenticationExtensionsClientInputs, PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
     ResidentKeyRequirement, User, UserVerificationRequirement,
 };
 use crate::errors::*;
@@ -24,7 +22,7 @@ pub struct RegisterArgs {
     pub exclude_list: Vec<PublicKeyCredentialDescriptor>,
     pub user_verification_req: UserVerificationRequirement,
     pub resident_key_req: ResidentKeyRequirement,
-    pub extensions: MakeCredentialsExtensions,
+    pub extensions: AuthenticationExtensionsClientInputs,
     pub pin: Option<Pin>,
     pub use_ctap1_fallback: bool,
 }
@@ -37,16 +35,10 @@ pub struct SignArgs {
     pub allow_list: Vec<PublicKeyCredentialDescriptor>,
     pub user_verification_req: UserVerificationRequirement,
     pub user_presence_req: bool,
-    pub extensions: GetAssertionExtensions,
+    pub extensions: AuthenticationExtensionsClientInputs,
     pub pin: Option<Pin>,
     pub alternate_rp_id: Option<String>,
     pub use_ctap1_fallback: bool,
-    // Todo: Extensions
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct AssertionExtensions {
-    pub hmac_secret: Option<HmacSecretExtension>,
 }
 
 pub trait AuthenticatorTransport {

--- a/src/authenticatorservice.rs
+++ b/src/authenticatorservice.rs
@@ -38,7 +38,6 @@ pub struct SignArgs {
     pub user_presence_req: bool,
     pub extensions: AuthenticationExtensionsClientInputs,
     pub pin: Option<Pin>,
-    pub alternate_rp_id: Option<String>,
     pub use_ctap1_fallback: bool,
 }
 
@@ -472,7 +471,6 @@ mod tests {
                     user_presence_req: true,
                     extensions: Default::default(),
                     pin: None,
-                    alternate_rp_id: None,
                     use_ctap1_fallback: false,
                 },
                 status_tx,
@@ -572,7 +570,6 @@ mod tests {
                     user_presence_req: true,
                     extensions: Default::default(),
                     pin: None,
-                    alternate_rp_id: None,
                     use_ctap1_fallback: false,
                 },
                 status_tx,

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -441,7 +441,6 @@ impl Serialize for Curve {
     }
 }
 
-
 impl TryFrom<i64> for Curve {
     type Error = CryptoError;
     fn try_from(i: i64) -> Result<Self, Self::Error> {
@@ -604,9 +603,15 @@ impl TryFrom<i64> for COSEAlgorithm {
             i if i == COSEAlgorithm::SHAKE256 as i64 => Ok(COSEAlgorithm::SHAKE256),
             i if i == COSEAlgorithm::SHA512 as i64 => Ok(COSEAlgorithm::SHA512),
             i if i == COSEAlgorithm::SHA384 as i64 => Ok(COSEAlgorithm::SHA384),
-            i if i == COSEAlgorithm::RSAES_OAEP_SHA_512 as i64 => Ok(COSEAlgorithm::RSAES_OAEP_SHA_512),
-            i if i == COSEAlgorithm::RSAES_OAEP_SHA_256 as i64 => Ok(COSEAlgorithm::RSAES_OAEP_SHA_256),
-            i if i == COSEAlgorithm::RSAES_OAEP_RFC_8017_default as i64 => Ok(COSEAlgorithm::RSAES_OAEP_RFC_8017_default),
+            i if i == COSEAlgorithm::RSAES_OAEP_SHA_512 as i64 => {
+                Ok(COSEAlgorithm::RSAES_OAEP_SHA_512)
+            }
+            i if i == COSEAlgorithm::RSAES_OAEP_SHA_256 as i64 => {
+                Ok(COSEAlgorithm::RSAES_OAEP_SHA_256)
+            }
+            i if i == COSEAlgorithm::RSAES_OAEP_RFC_8017_default as i64 => {
+                Ok(COSEAlgorithm::RSAES_OAEP_RFC_8017_default)
+            }
             i if i == COSEAlgorithm::PS512 as i64 => Ok(COSEAlgorithm::PS512),
             i if i == COSEAlgorithm::PS384 as i64 => Ok(COSEAlgorithm::PS384),
             i if i == COSEAlgorithm::PS256 as i64 => Ok(COSEAlgorithm::PS256),
@@ -627,10 +632,18 @@ impl TryFrom<i64> for COSEAlgorithm {
             i if i == COSEAlgorithm::SHA256 as i64 => Ok(COSEAlgorithm::SHA256),
             i if i == COSEAlgorithm::SHA256_64 as i64 => Ok(COSEAlgorithm::SHA256_64),
             i if i == COSEAlgorithm::SHA1 as i64 => Ok(COSEAlgorithm::SHA1),
-            i if i == COSEAlgorithm::Direct_HKDF_AES256 as i64 => Ok(COSEAlgorithm::Direct_HKDF_AES256),
-            i if i == COSEAlgorithm::Direct_HKDF_AES128 as i64 => Ok(COSEAlgorithm::Direct_HKDF_AES128),
-            i if i == COSEAlgorithm::Direct_HKDF_SHA512 as i64 => Ok(COSEAlgorithm::Direct_HKDF_SHA512),
-            i if i == COSEAlgorithm::Direct_HKDF_SHA256 as i64 => Ok(COSEAlgorithm::Direct_HKDF_SHA256),
+            i if i == COSEAlgorithm::Direct_HKDF_AES256 as i64 => {
+                Ok(COSEAlgorithm::Direct_HKDF_AES256)
+            }
+            i if i == COSEAlgorithm::Direct_HKDF_AES128 as i64 => {
+                Ok(COSEAlgorithm::Direct_HKDF_AES128)
+            }
+            i if i == COSEAlgorithm::Direct_HKDF_SHA512 as i64 => {
+                Ok(COSEAlgorithm::Direct_HKDF_SHA512)
+            }
+            i if i == COSEAlgorithm::Direct_HKDF_SHA256 as i64 => {
+                Ok(COSEAlgorithm::Direct_HKDF_SHA256)
+            }
             i if i == COSEAlgorithm::EDDSA as i64 => Ok(COSEAlgorithm::EDDSA),
             i if i == COSEAlgorithm::ES256 as i64 => Ok(COSEAlgorithm::ES256),
             i if i == COSEAlgorithm::Direct as i64 => Ok(COSEAlgorithm::Direct),
@@ -644,19 +657,37 @@ impl TryFrom<i64> for COSEAlgorithm {
             i if i == COSEAlgorithm::HMAC256_256 as i64 => Ok(COSEAlgorithm::HMAC256_256),
             i if i == COSEAlgorithm::HMAC384_384 as i64 => Ok(COSEAlgorithm::HMAC384_384),
             i if i == COSEAlgorithm::HMAC512_512 as i64 => Ok(COSEAlgorithm::HMAC512_512),
-            i if i == COSEAlgorithm::AES_CCM_16_64_128 as i64 => Ok(COSEAlgorithm::AES_CCM_16_64_128),
-            i if i == COSEAlgorithm::AES_CCM_16_64_256 as i64 => Ok(COSEAlgorithm::AES_CCM_16_64_256),
-            i if i == COSEAlgorithm::AES_CCM_64_64_128 as i64 => Ok(COSEAlgorithm::AES_CCM_64_64_128),
-            i if i == COSEAlgorithm::AES_CCM_64_64_256 as i64 => Ok(COSEAlgorithm::AES_CCM_64_64_256),
+            i if i == COSEAlgorithm::AES_CCM_16_64_128 as i64 => {
+                Ok(COSEAlgorithm::AES_CCM_16_64_128)
+            }
+            i if i == COSEAlgorithm::AES_CCM_16_64_256 as i64 => {
+                Ok(COSEAlgorithm::AES_CCM_16_64_256)
+            }
+            i if i == COSEAlgorithm::AES_CCM_64_64_128 as i64 => {
+                Ok(COSEAlgorithm::AES_CCM_64_64_128)
+            }
+            i if i == COSEAlgorithm::AES_CCM_64_64_256 as i64 => {
+                Ok(COSEAlgorithm::AES_CCM_64_64_256)
+            }
             i if i == COSEAlgorithm::AES_MAC_128_64 as i64 => Ok(COSEAlgorithm::AES_MAC_128_64),
             i if i == COSEAlgorithm::AES_MAC_256_64 as i64 => Ok(COSEAlgorithm::AES_MAC_256_64),
-            i if i == COSEAlgorithm::ChaCha20_Poly1305 as i64 => Ok(COSEAlgorithm::ChaCha20_Poly1305),
+            i if i == COSEAlgorithm::ChaCha20_Poly1305 as i64 => {
+                Ok(COSEAlgorithm::ChaCha20_Poly1305)
+            }
             i if i == COSEAlgorithm::AES_MAC_128_128 as i64 => Ok(COSEAlgorithm::AES_MAC_128_128),
             i if i == COSEAlgorithm::AES_MAC_256_128 as i64 => Ok(COSEAlgorithm::AES_MAC_256_128),
-            i if i == COSEAlgorithm::AES_CCM_16_128_128 as i64 => Ok(COSEAlgorithm::AES_CCM_16_128_128),
-            i if i == COSEAlgorithm::AES_CCM_16_128_256 as i64 => Ok(COSEAlgorithm::AES_CCM_16_128_256),
-            i if i == COSEAlgorithm::AES_CCM_64_128_128 as i64 => Ok(COSEAlgorithm::AES_CCM_64_128_128),
-            i if i == COSEAlgorithm::AES_CCM_64_128_256 as i64 => Ok(COSEAlgorithm::AES_CCM_64_128_256),
+            i if i == COSEAlgorithm::AES_CCM_16_128_128 as i64 => {
+                Ok(COSEAlgorithm::AES_CCM_16_128_128)
+            }
+            i if i == COSEAlgorithm::AES_CCM_16_128_256 as i64 => {
+                Ok(COSEAlgorithm::AES_CCM_16_128_256)
+            }
+            i if i == COSEAlgorithm::AES_CCM_64_128_128 as i64 => {
+                Ok(COSEAlgorithm::AES_CCM_64_128_128)
+            }
+            i if i == COSEAlgorithm::AES_CCM_64_128_256 as i64 => {
+                Ok(COSEAlgorithm::AES_CCM_64_128_256)
+            }
             i if i == COSEAlgorithm::IV_GENERATION as i64 => Ok(COSEAlgorithm::IV_GENERATION),
             i if i == COSEAlgorithm::INSECURE_RS1 as i64 => Ok(COSEAlgorithm::INSECURE_RS1),
             _ => Err(CryptoError::UnknownAlgorithm),
@@ -777,9 +808,9 @@ impl TryFrom<i64> for COSEKeyTypeId {
     type Error = CryptoError;
     fn try_from(i: i64) -> Result<Self, Self::Error> {
         match i {
-             i if i == COSEKeyTypeId::OKP as i64 => Ok(COSEKeyTypeId::OKP),
-             i if i == COSEKeyTypeId::EC2 as i64 => Ok(COSEKeyTypeId::EC2),
-             i if i == COSEKeyTypeId::RSA as i64 => Ok(COSEKeyTypeId::RSA),
+            i if i == COSEKeyTypeId::OKP as i64 => Ok(COSEKeyTypeId::OKP),
+            i if i == COSEKeyTypeId::EC2 as i64 => Ok(COSEKeyTypeId::EC2),
+            i if i == COSEKeyTypeId::RSA as i64 => Ok(COSEKeyTypeId::RSA),
             _ => Err(CryptoError::UnknownKeyType),
         }
     }
@@ -1097,7 +1128,7 @@ mod test {
         Curve, PinProtocolImpl, PinUvAuth1, PinUvAuth2, PinUvAuthProtocol, PublicInputs,
         SharedSecret,
     };
-    use crate::crypto::{COSEEC2Key, COSERSAKey, COSEKeyType};
+    use crate::crypto::{COSEEC2Key, COSEKeyType, COSERSAKey};
     use crate::ctap2::attestation::AAGuid;
     use crate::ctap2::commands::client_pin::Pin;
     use crate::ctap2::commands::get_info::{
@@ -1129,7 +1160,7 @@ mod test {
             0xa4, 0xcc, 0x21, 0x44, 0x58, 0x8b, 0xcd, 0x98, 0xe4, 0x3d, 0x53, 0x20, 0xfc, 0xfc,
             0x7b, 0x9f, 0x43, 0x35, 0xfb, 0x38, 0x37, 0x23, 0xd0, 0x76, 0xe3, 0x3d, 0x4f, 0x89,
             0x9b, 0x89, 0x32, 0x81, 0x89, 0xed, 0x58, 0xc0, 0x80, 0x18, 0x83, 0x5b, 0xaf, 0x5a,
-            0xa5, 0x21, 0x43, 0x01, 0x00, 0x01
+            0xa5, 0x21, 0x43, 0x01, 0x00, 0x01,
         ];
         let expected: COSEKey = COSEKey {
             alg: COSEAlgorithm::RS256,
@@ -1155,7 +1186,7 @@ mod test {
                     0x99, 0x41, 0x20, 0x5e, 0x1a, 0xa4, 0xcc, 0x21, 0x44, 0x58, 0x8b, 0xcd, 0x98,
                     0xe4, 0x3d, 0x53, 0x20, 0xfc, 0xfc, 0x7b, 0x9f, 0x43, 0x35, 0xfb, 0x38, 0x37,
                     0x23, 0xd0, 0x76, 0xe3, 0x3d, 0x4f, 0x89, 0x9b, 0x89, 0x32, 0x81, 0x89, 0xed,
-                    0x58, 0xc0, 0x80, 0x18, 0x83, 0x5b, 0xaf, 0x5a, 0xa5
+                    0x58, 0xc0, 0x80, 0x18, 0x83, 0x5b, 0xaf, 0x5a, 0xa5,
                 ],
             }),
         };

--- a/src/ctap2/attestation.rs
+++ b/src/ctap2/attestation.rs
@@ -68,12 +68,12 @@ impl<'de> Deserialize<'de> for HmacSecretResponse {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Extension {
-    #[serde(rename = "minPinLength", skip_serializing_if = "Option::is_none")]
-    pub min_pin_length: Option<u64>,
-    #[serde(rename = "hmac-secret", skip_serializing_if = "Option::is_none")]
-    pub hmac_secret: Option<HmacSecretResponse>,
     #[serde(rename = "credProtect", skip_serializing_if = "Option::is_none")]
     pub cred_protect: Option<CredentialProtectionPolicy>,
+    #[serde(rename = "hmac-secret", skip_serializing_if = "Option::is_none")]
+    pub hmac_secret: Option<HmacSecretResponse>,
+    #[serde(rename = "minPinLength", skip_serializing_if = "Option::is_none")]
+    pub min_pin_length: Option<u64>,
 }
 
 impl Extension {

--- a/src/ctap2/attestation.rs
+++ b/src/ctap2/attestation.rs
@@ -68,15 +68,15 @@ impl<'de> Deserialize<'de> for HmacSecretResponse {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Extension {
-    #[serde(rename = "pinMinLength", skip_serializing_if = "Option::is_none")]
-    pub pin_min_length: Option<u64>,
+    #[serde(rename = "minPinLength", skip_serializing_if = "Option::is_none")]
+    pub min_pin_length: Option<u64>,
     #[serde(rename = "hmac-secret", skip_serializing_if = "Option::is_none")]
     pub hmac_secret: Option<HmacSecretResponse>,
 }
 
 impl Extension {
     fn has_some(&self) -> bool {
-        self.pin_min_length.is_some() || self.hmac_secret.is_some()
+        self.min_pin_length.is_some() || self.hmac_secret.is_some()
     }
 }
 

--- a/src/ctap2/attestation.rs
+++ b/src/ctap2/attestation.rs
@@ -1,6 +1,6 @@
 use super::utils::{from_slice_stream, read_be_u16, read_be_u32, read_byte};
 use crate::crypto::COSEAlgorithm;
-use crate::ctap2::server::RpIdHash;
+use crate::ctap2::server::{CredentialProtectionPolicy, RpIdHash};
 use crate::ctap2::utils::serde_parse_err;
 use crate::{crypto::COSEKey, errors::AuthenticatorError};
 use base64::Engine;
@@ -72,11 +72,13 @@ pub struct Extension {
     pub min_pin_length: Option<u64>,
     #[serde(rename = "hmac-secret", skip_serializing_if = "Option::is_none")]
     pub hmac_secret: Option<HmacSecretResponse>,
+    #[serde(rename = "credProtect", skip_serializing_if = "Option::is_none")]
+    pub cred_protect: Option<CredentialProtectionPolicy>,
 }
 
 impl Extension {
     fn has_some(&self) -> bool {
-        self.min_pin_length.is_some() || self.hmac_secret.is_some()
+        self.min_pin_length.is_some() || self.hmac_secret.is_some() || self.cred_protect.is_some()
     }
 }
 

--- a/src/ctap2/attestation.rs
+++ b/src/ctap2/attestation.rs
@@ -77,7 +77,7 @@ pub struct Extension {
 }
 
 impl Extension {
-    fn has_some(&self) -> bool {
+    pub fn has_some(&self) -> bool {
         self.min_pin_length.is_some() || self.hmac_secret.is_some() || self.cred_protect.is_some()
     }
 }

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -12,6 +12,7 @@ use crate::ctap2::client_data::ClientDataHash;
 use crate::ctap2::commands::get_next_assertion::GetNextAssertion;
 use crate::ctap2::commands::make_credentials::UserVerification;
 use crate::ctap2::server::{
+    AuthenticationExtensionsClientInputs,
     PublicKeyCredentialDescriptor, RelyingPartyWrapper, RpIdHash, User, UserVerificationRequirement,
 };
 use crate::ctap2::utils::{read_be_u32, read_byte};
@@ -134,6 +135,12 @@ impl Serialize for HmacSecretExtension {
 #[derive(Debug, Clone, Default)]
 pub struct GetAssertionExtensions {
     pub hmac_secret: Option<HmacSecretExtension>,
+}
+
+impl From<AuthenticationExtensionsClientInputs> for GetAssertionExtensions {
+    fn from(_input: AuthenticationExtensionsClientInputs) -> Self {
+        Default::default()
+    }
 }
 
 impl Serialize for GetAssertionExtensions {

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -133,9 +133,11 @@ impl Serialize for HmacSecretExtension {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default, Clone, Serialize)]
 pub struct GetAssertionExtensions {
+    #[serde(skip_serializing)]
     pub app_id: Option<String>,
+    #[serde(rename = "hmac-secret", skip_serializing_if = "Option::is_none")]
     pub hmac_secret: Option<HmacSecretExtension>,
 }
 
@@ -148,19 +150,8 @@ impl From<AuthenticationExtensionsClientInputs> for GetAssertionExtensions {
     }
 }
 
-impl Serialize for GetAssertionExtensions {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(1))?;
-        map.serialize_entry(&"hmac-secret", &self.hmac_secret)?;
-        map.end()
-    }
-}
-
 impl GetAssertionExtensions {
-    fn has_extensions(&self) -> bool {
+    fn has_content(&self) -> bool {
         self.hmac_secret.is_some()
     }
 }
@@ -275,7 +266,7 @@ impl Serialize for GetAssertion {
         if !self.allow_list.is_empty() {
             map_len += 1;
         }
-        if self.extensions.has_extensions() {
+        if self.extensions.has_content() {
             map_len += 1;
         }
         if self.options.has_some() {
@@ -301,7 +292,7 @@ impl Serialize for GetAssertion {
         if !self.allow_list.is_empty() {
             map.serialize_entry(&3, &self.allow_list)?;
         }
-        if self.extensions.has_extensions() {
+        if self.extensions.has_content() {
             map.serialize_entry(&4, &self.extensions)?;
         }
         if self.options.has_some() {

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -340,6 +340,10 @@ pub struct AuthenticatorInfo {
 }
 
 impl AuthenticatorInfo {
+    pub fn supports_cred_protect(&self) -> bool {
+        self.extensions.contains(&"credProtect".to_string())
+    }
+
     pub fn supports_hmac_secret(&self) -> bool {
         self.extensions.contains(&"hmac-secret".to_string())
     }

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -500,9 +500,8 @@ impl RequestCtap2 for MakeCredentials {
         if input.len() == 1 {
             if status.is_ok() {
                 return Err(HIDError::Command(CommandError::InputTooSmall));
-            } else {
-                return Err(HIDError::Command(CommandError::StatusCode(status, None)));
             }
+            return Err(HIDError::Command(CommandError::StatusCode(status, None)));
         }
 
         if status.is_ok() {

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -13,6 +13,7 @@ use crate::ctap2::attestation::{
 };
 use crate::ctap2::client_data::ClientDataHash;
 use crate::ctap2::server::{
+    AuthenticationExtensionsClientInputs,
     PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
     RelyingPartyWrapper, RpIdHash, User, UserVerificationRequirement,
 };
@@ -231,6 +232,12 @@ pub struct MakeCredentialsExtensions {
 impl MakeCredentialsExtensions {
     fn has_extensions(&self) -> bool {
         self.pin_min_length.or(self.hmac_secret).is_some()
+    }
+}
+
+impl From<AuthenticationExtensionsClientInputs> for MakeCredentialsExtensions {
+    fn from(_input: AuthenticationExtensionsClientInputs) -> Self {
+        Default::default()
     }
 }
 

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -226,7 +226,7 @@ impl UserVerification for MakeCredentialsOptions {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Default, Clone, Serialize)]
 pub struct MakeCredentialsExtensions {
     #[serde(skip_serializing)]
     pub cred_props: Option<bool>,
@@ -239,7 +239,7 @@ pub struct MakeCredentialsExtensions {
 }
 
 impl MakeCredentialsExtensions {
-    fn has_extensions(&self) -> bool {
+    fn has_content(&self) -> bool {
         self.min_pin_length.is_some() || self.hmac_secret.is_some() || self.cred_protect.is_some()
     }
 }
@@ -390,7 +390,7 @@ impl Serialize for MakeCredentials {
         if !self.exclude_list.is_empty() {
             map_len += 1;
         }
-        if self.extensions.has_extensions() {
+        if self.extensions.has_content() {
             map_len += 1;
         }
         if self.options.has_some() {
@@ -420,7 +420,7 @@ impl Serialize for MakeCredentials {
         if !self.exclude_list.is_empty() {
             map.serialize_entry(&0x05, &self.exclude_list)?;
         }
-        if self.extensions.has_extensions() {
+        if self.extensions.has_content() {
             map.serialize_entry(&0x06, &self.extensions)?;
         }
         if self.options.has_some() {

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -228,8 +228,8 @@ impl UserVerification for MakeCredentialsOptions {
 
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct MakeCredentialsExtensions {
-    #[serde(rename = "pinMinLength", skip_serializing_if = "Option::is_none")]
-    pub pin_min_length: Option<bool>,
+    #[serde(rename = "minPinLength", skip_serializing_if = "Option::is_none")]
+    pub min_pin_length: Option<bool>,
     #[serde(rename = "hmac-secret", skip_serializing_if = "Option::is_none")]
     pub hmac_secret: Option<bool>,
     #[serde(skip_serializing)]
@@ -238,7 +238,7 @@ pub struct MakeCredentialsExtensions {
 
 impl MakeCredentialsExtensions {
     fn has_extensions(&self) -> bool {
-        self.pin_min_length.or(self.hmac_secret).is_some()
+        self.min_pin_length.or(self.hmac_secret).is_some()
     }
 }
 
@@ -246,6 +246,7 @@ impl From<AuthenticationExtensionsClientInputs> for MakeCredentialsExtensions {
     fn from(input: AuthenticationExtensionsClientInputs) -> Self {
         Self {
             cred_props: input.cred_props,
+            min_pin_length: input.min_pin_length,
             ..Default::default()
         }
     }

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -251,7 +251,6 @@ impl From<AuthenticationExtensionsClientInputs> for MakeCredentialsExtensions {
             cred_protect: input.credential_protection_policy,
             hmac_secret: input.hmac_create_secret,
             min_pin_length: input.min_pin_length,
-            ..Default::default()
         }
     }
 }

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -13,7 +13,7 @@ use crate::ctap2::attestation::{
 };
 use crate::ctap2::client_data::ClientDataHash;
 use crate::ctap2::server::{
-    AuthenticationExtensionsClientInputs,
+    AuthenticationExtensionsClientInputs, AuthenticationExtensionsClientOutputs,
     PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
     RelyingPartyWrapper, RpIdHash, User, UserVerificationRequirement,
 };
@@ -34,6 +34,7 @@ use std::io::{Cursor, Read};
 #[derive(Debug, PartialEq, Eq)]
 pub struct MakeCredentialsResult {
     pub att_obj: AttestationObject,
+    pub extensions: AuthenticationExtensionsClientOutputs,
 }
 
 impl MakeCredentialsResult {
@@ -99,7 +100,10 @@ impl MakeCredentialsResult {
             att_stmt,
         };
 
-        Ok(Self { att_obj })
+        Ok(Self {
+            att_obj,
+            extensions: Default::default(),
+        })
     }
 }
 
@@ -182,6 +186,7 @@ impl<'de> Deserialize<'de> for MakeCredentialsResult {
                         auth_data,
                         att_stmt,
                     },
+                    extensions: Default::default(),
                 })
             }
         }
@@ -606,6 +611,7 @@ pub mod test {
 
         let expected = MakeCredentialsResult {
             att_obj: create_attestation_obj(),
+            extensions: Default::default(),
         };
 
         assert_eq!(make_cred_result, expected);
@@ -760,7 +766,10 @@ pub mod test {
             }),
         };
 
-        let expected = MakeCredentialsResult { att_obj };
+        let expected = MakeCredentialsResult {
+            att_obj,
+            extensions: Default::default(),
+        };
 
         assert_eq!(make_cred_result, expected);
     }

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -430,7 +430,7 @@ pub fn register<Dev: FidoDevice>(
         args.pub_cred_params,
         args.exclude_list,
         options,
-        args.extensions,
+        args.extensions.into(),
     );
 
     let mut skip_uv = false;
@@ -556,7 +556,7 @@ pub fn sign<Dev: FidoDevice>(
             user_presence: Some(args.user_presence_req),
             user_verification: None,
         },
-        args.extensions,
+        args.extensions.into(),
     );
 
     let mut skip_uv = false;

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -531,19 +531,19 @@ pub fn sign<Dev: FidoDevice>(
     let mut allow_list = args.allow_list;
     let mut rp_id = args.relying_party_id;
     let client_data_hash = ClientDataHash(args.client_data_hash);
-    if let Some(alt_rp_id) = args.alternate_rp_id {
+    if let Some(ref app_id) = args.extensions.app_id {
         if !allow_list.is_empty() {
             // Try to silently discover U2F credentials that require the FIDO App ID extension. If
             // any are found, we should use the alternate RP ID instead of the provided RP ID.
             let silent_creds = silently_discover_credentials(
                 dev,
                 &allow_list,
-                &RelyingPartyWrapper::from(alt_rp_id.as_str()),
+                &RelyingPartyWrapper::from(app_id.as_str()),
                 &client_data_hash,
             );
             if !silent_creds.is_empty() {
                 allow_list = silent_creds;
-                rp_id = alt_rp_id;
+                rp_id = app_id.to_string();
             }
         }
     }

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -35,7 +35,8 @@ use crate::ctap2::preflight::{
     silently_discover_credentials,
 };
 use crate::ctap2::server::{
-    RelyingPartyWrapper, ResidentKeyRequirement, UserVerificationRequirement,
+    CredentialProtectionPolicy, RelyingPartyWrapper, ResidentKeyRequirement,
+    UserVerificationRequirement,
 };
 use crate::errors::{AuthenticatorError, UnsupportedOption};
 use crate::statecallback::StateCallback;
@@ -421,6 +422,24 @@ pub fn register<Dev: FidoDevice>(
             )));
             return false;
         }
+    }
+
+    // Client extension processing for credProtect:
+    // "When enforceCredentialProtectionPolicy is true, and credentialProtectionPolicy's value is
+    // [not "Optional"], the platform SHOULD NOT create the credential in a way that does not
+    // implement the requested protection policy. (For example, by creating it on an authenticator
+    // that does not support this extension.)"
+    if args.extensions.enforce_credential_protection_policy == Some(true)
+        && args.extensions.credential_protection_policy
+            != Some(CredentialProtectionPolicy::UserVerificationOptional)
+        && dev
+            .get_authenticator_info()
+            .map_or(false, |info| !info.supports_cred_protect())
+    {
+        callback.call(Err(AuthenticatorError::UnsupportedOption(
+            UnsupportedOption::CredProtect,
+        )));
+        return false;
     }
 
     let mut makecred = MakeCredentials::new(

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -429,12 +429,13 @@ pub fn register<Dev: FidoDevice>(
     // [not "Optional"], the platform SHOULD NOT create the credential in a way that does not
     // implement the requested protection policy. (For example, by creating it on an authenticator
     // that does not support this extension.)"
+    let dev_supports_cred_protect = dev
+        .get_authenticator_info()
+        .map_or(false, |info| info.supports_cred_protect());
     if args.extensions.enforce_credential_protection_policy == Some(true)
         && args.extensions.credential_protection_policy
             != Some(CredentialProtectionPolicy::UserVerificationOptional)
-        && dev
-            .get_authenticator_info()
-            .map_or(false, |info| !info.supports_cred_protect())
+        && !dev_supports_cred_protect
     {
         callback.call(Err(AuthenticatorError::UnsupportedOption(
             UnsupportedOption::CredProtect,

--- a/src/ctap2/preflight.rs
+++ b/src/ctap2/preflight.rs
@@ -1,7 +1,6 @@
 use super::client_data::ClientDataHash;
-use super::commands::get_assertion::{GetAssertion, GetAssertionOptions};
+use super::commands::get_assertion::{GetAssertion, GetAssertionExtensions, GetAssertionOptions};
 use super::commands::{PinUvAuthCommand, RequestCtap1, Retryable};
-use crate::authenticatorservice::GetAssertionExtensions;
 use crate::consts::{PARAMETER_SIZE, U2F_AUTHENTICATE, U2F_CHECK_IS_REGISTERED};
 use crate::crypto::PinUvAuthToken;
 use crate::ctap2::server::{PublicKeyCredentialDescriptor, RelyingPartyWrapper};

--- a/src/ctap2/preflight.rs
+++ b/src/ctap2/preflight.rs
@@ -165,7 +165,7 @@ pub(crate) fn do_credential_list_filtering_ctap2<Dev: FidoDevice>(
                 // This chunk contains a key_handle that is already known to the device.
                 // Filter out all credentials the device returned. Those are valid.
                 let credential_ids = response
-                    .0
+                    .assertions
                     .iter()
                     .filter_map(|a| a.credentials.clone())
                     .collect();

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -333,6 +333,7 @@ pub enum UserVerificationRequirement {
 pub struct AuthenticationExtensionsClientInputs {
     pub app_id: Option<String>,
     pub cred_props: Option<bool>,
+    pub min_pin_length: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -385,9 +385,10 @@ impl<'de> Deserialize<'de> for CredentialProtectionPolicy {
 pub struct AuthenticationExtensionsClientInputs {
     pub app_id: Option<String>,
     pub cred_props: Option<bool>,
-    pub min_pin_length: Option<bool>,
     pub credential_protection_policy: Option<CredentialProtectionPolicy>,
     pub enforce_credential_protection_policy: Option<bool>,
+    pub hmac_create_secret: Option<bool>,
+    pub min_pin_length: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -399,6 +400,7 @@ pub struct CredentialProperties {
 pub struct AuthenticationExtensionsClientOutputs {
     pub app_id: Option<bool>,
     pub cred_props: Option<CredentialProperties>,
+    pub hmac_create_secret: Option<bool>,
 }
 
 #[cfg(test)]

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -329,11 +329,20 @@ pub enum UserVerificationRequirement {
     Required,
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct AuthenticationExtensionsClientInputs;
+#[derive(Clone, Debug, Default)]
+pub struct AuthenticationExtensionsClientInputs {
+    pub cred_props: Option<bool>,
+}
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct AuthenticationExtensionsClientOutputs;
+pub struct CredentialProperties {
+    pub rk: bool,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AuthenticationExtensionsClientOutputs {
+    pub cred_props: Option<CredentialProperties>,
+}
 
 #[cfg(test)]
 mod test {

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -329,6 +329,12 @@ pub enum UserVerificationRequirement {
     Required,
 }
 
+#[derive(Copy, Clone, Debug)]
+pub struct AuthenticationExtensionsClientInputs;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AuthenticationExtensionsClientOutputs;
+
 #[cfg(test)]
 mod test {
     use super::{

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -331,6 +331,7 @@ pub enum UserVerificationRequirement {
 
 #[derive(Clone, Debug, Default)]
 pub struct AuthenticationExtensionsClientInputs {
+    pub app_id: Option<String>,
     pub cred_props: Option<bool>,
 }
 
@@ -341,6 +342,7 @@ pub struct CredentialProperties {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct AuthenticationExtensionsClientOutputs {
+    pub app_id: Option<bool>,
     pub cred_props: Option<CredentialProperties>,
 }
 

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -3,7 +3,7 @@ use crate::{errors::AuthenticatorError, AuthenticatorTransports, KeyHandle};
 use base64::Engine;
 use serde::de::MapAccess;
 use serde::{
-    de::{Error as SerdeError, Visitor},
+    de::{Error as SerdeError, Unexpected, Visitor},
     ser::SerializeMap,
     Deserialize, Deserializer, Serialize, Serializer,
 };
@@ -329,11 +329,65 @@ pub enum UserVerificationRequirement {
     Required,
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum CredentialProtectionPolicy {
+    UserVerificationOptional = 1,
+    UserVerificationOptionalWithCredentialIDList = 2,
+    UserVerificationRequired = 3,
+}
+
+impl Serialize for CredentialProtectionPolicy {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(*self as u64)
+    }
+}
+
+impl<'de> Deserialize<'de> for CredentialProtectionPolicy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CredentialProtectionPolicyVisitor;
+
+        impl<'de> Visitor<'de> for CredentialProtectionPolicyVisitor {
+            type Value = CredentialProtectionPolicy;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("an integer")
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: SerdeError,
+            {
+                match v {
+                    1 => Ok(CredentialProtectionPolicy::UserVerificationOptional),
+                    2 => Ok(
+                        CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIDList,
+                    ),
+                    3 => Ok(CredentialProtectionPolicy::UserVerificationRequired),
+                    _ => Err(SerdeError::invalid_value(
+                        Unexpected::Unsigned(v),
+                        &"valid CredentialProtectionPolicy",
+                    )),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(CredentialProtectionPolicyVisitor)
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct AuthenticationExtensionsClientInputs {
     pub app_id: Option<String>,
     pub cred_props: Option<bool>,
     pub min_pin_length: Option<bool>,
+    pub credential_protection_policy: Option<CredentialProtectionPolicy>,
+    pub enforce_credential_protection_policy: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,6 +13,7 @@ use std::sync::mpsc;
 
 #[derive(Debug)]
 pub enum UnsupportedOption {
+    CredProtect,
     EmptyAllowList,
     MaxPinLength,
     PubCredParams,

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -242,7 +242,7 @@ impl StateMachine {
                 ..Default::default()
             });
             app_ids.push(rp_id.hash().as_ref().to_vec());
-            if let Some(app_id) = args.alternate_rp_id {
+            if let Some(app_id) = args.extensions.app_id {
                 let app_id = RelyingPartyWrapper::Data(RelyingParty {
                     id: app_id,
                     ..Default::default()


### PR DESCRIPTION
The first two patches align the extension inputs and outputs in our API with WebAuthn. In the long run this will simplify how we pass extensions from Firefox (e.g. we could deserialize them from JSON in authrs_bridge).

I'm only adding partial support for hmac-secret; I've not added an `hmac_get_secret` field to `AuthenticationExtensionsClientInputs`. I'll add support for the PRF extension, which uses hmac-secret internally, in a later revision, but I don't think we'll ever want to give the client direct access to hmac-secret.

While this enables a lot of new behavior, it's all inert until we actually pass inputs from Firefox. I developed this along with a series of patches that enable the individual extensions in Firefox and those patches enable web platform tests and add mochitests for each.