### PR TITLE
Dont ignore cached PUATs for devices < FIDO_2_1

### DIFF
--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -886,8 +886,10 @@ pub(crate) fn bio_enrollment(
         Some(PinUvAuthResult::SuccessGetPinToken(t))
         | Some(PinUvAuthResult::SuccessGetPinUvAuthTokenUsingUvWithPermissions(t))
         | Some(PinUvAuthResult::SuccessGetPinUvAuthTokenUsingPinWithPermissions(t))
-            if t.permissions
-                .contains(PinUvAuthTokenPermission::BioEnrollment) =>
+            if !authinfo.versions.contains(&AuthenticatorVersion::FIDO_2_1) // Only 2.1 has a permission-system
+                || use_legacy_preview // Preview doesn't use permissions
+                || t.permissions
+                    .contains(PinUvAuthTokenPermission::BioEnrollment) =>
         {
             skip_puap = true;
             cached_puat = true;
@@ -1154,7 +1156,10 @@ pub(crate) fn credential_management(
         Some(PinUvAuthResult::SuccessGetPinToken(t))
         | Some(PinUvAuthResult::SuccessGetPinUvAuthTokenUsingUvWithPermissions(t))
         | Some(PinUvAuthResult::SuccessGetPinUvAuthTokenUsingPinWithPermissions(t))
-            if t.permissions == PinUvAuthTokenPermission::CredentialManagement =>
+            if !authinfo.versions.contains(&AuthenticatorVersion::FIDO_2_1) // Only 2.1 has a permission-system
+                || use_legacy_preview // Preview doesn't use permissions
+                || t.permissions
+                    .contains(PinUvAuthTokenPermission::CredentialManagement) =>
         {
             skip_puap = true;
             cached_puat = true;
@@ -1432,7 +1437,8 @@ pub(crate) fn configure_authenticator(
         Some(PinUvAuthResult::SuccessGetPinToken(t))
         | Some(PinUvAuthResult::SuccessGetPinUvAuthTokenUsingUvWithPermissions(t))
         | Some(PinUvAuthResult::SuccessGetPinUvAuthTokenUsingPinWithPermissions(t))
-            if t.permissions == PinUvAuthTokenPermission::AuthenticatorConfiguration =>
+            if t.permissions
+                .contains(PinUvAuthTokenPermission::AuthenticatorConfiguration) =>
         {
             skip_puap = true;
             cached_puat = true;


### PR DESCRIPTION
The caching didn't work for devices that do not yet support the permissions-system.
We can ignore the permissions, if we are in legacy-mode or on a device not implementing full-blown 2.1

Yes, "using legacy" and "not having full-blown 2.1" should be interchangeable, but are not always.
My nitrokey3 for example reports to only implement 2_1_PRE, but also reports to implement both the Preview and the full credentialManagement-command. Probably a bug on their side, but it doesn't us hurt to check both.

Also, in the last PR I forgot the `==` vs. `contains()`-fix for CredentialManagement and AuthConfiguration.