### PR TITLE
Use StatusUpdate for signature selection

### DIFF
--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -7,8 +7,9 @@ use authenticator::{
     crypto::COSEAlgorithm,
     ctap2::server::{
         AuthenticationExtensionsClientInputs, CredentialProtectionPolicy,
-        PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
-        ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
+        PublicKeyCredentialDescriptor, PublicKeyCredentialParameters,
+        PublicKeyCredentialUserEntity, RelyingParty, ResidentKeyRequirement, Transport,
+        UserVerificationRequirement,
     },
     statecallback::StateCallback,
     Pin, StatusPinUv, StatusUpdate,
@@ -139,7 +140,7 @@ fn main() {
         }
     });
 
-    let user = User {
+    let user = PublicKeyCredentialUserEntity {
         id: "user_id".as_bytes().to_vec(),
         name: Some("A. User".to_string()),
         display_name: None,

--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -133,6 +133,9 @@ fn main() {
             Ok(StatusUpdate::PinUvError(e)) => {
                 panic!("Unexpected error: {:?}", e)
             }
+            Ok(StatusUpdate::SelectResultNotice(_, _)) => {
+                panic!("Unexpected select device notice")
+            }
             Err(RecvError) => {
                 println!("STATUS: end");
                 return;

--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -16,7 +16,8 @@ use authenticator::{
 use getopts::Options;
 use sha2::{Digest, Sha256};
 use std::sync::mpsc::{channel, RecvError};
-use std::{env, thread};
+use std::{env, io, thread};
+use std::io::Write;
 
 fn print_usage(program: &str, opts: Options) {
     println!("------------------------------------------------------------------------");
@@ -26,6 +27,37 @@ fn print_usage(program: &str, opts: Options) {
     println!("------------------------------------------------------------------------");
     let brief = format!("Usage: {program} [options]");
     print!("{}", opts.usage(&brief));
+}
+
+fn ask_user_choice(choices: &[PublicKeyCredentialUserEntity]) -> Option<usize> {
+    for (idx, op) in choices.iter().enumerate() {
+        println!("({idx}) \"{}\"", op.name.as_ref().unwrap());
+    }
+    println!("({}) Cancel", choices.len());
+
+    let mut input = String::new();
+    loop {
+        input.clear();
+        print!("Your choice: ");
+        io::stdout()
+            .lock()
+            .flush()
+            .expect("Failed to flush stdout!");
+        io::stdin()
+            .read_line(&mut input)
+            .expect("error: unable to read user input");
+        if let Ok(idx) = input.trim().parse::<usize>() {
+            if idx < choices.len() {
+                // Add a newline in case of success for better separation of in/output
+                println!();
+                return Some(idx);
+            } else if idx == choices.len() {
+                println!();
+                return None;
+            }
+            println!("invalid input");
+        }
+    }
 }
 
 fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms: u64) {
@@ -97,6 +129,9 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
             }
             Ok(StatusUpdate::PinUvError(e)) => {
                 panic!("Unexpected error: {:?}", e)
+            }
+            Ok(StatusUpdate::SelectResultNotice(_, _)) => {
+                panic!("Unexpected select result notice")
             }
             Err(RecvError) => {
                 println!("STATUS: end");
@@ -181,6 +216,10 @@ fn main() {
         "timeout in seconds",
         "SEC",
     );
+    opts.optflag(
+        "s",
+        "skip_reg",
+        "Skip registration");
 
     opts.optflag("h", "help", "print this help menu");
     let matches = match opts.parse(&args[1..]) {
@@ -208,8 +247,10 @@ fn main() {
         }
     };
 
-    for username in &["A. User", "A. Nother", "Dr. Who"] {
-        register_user(&mut manager, username, timeout_ms)
+    if !matches.opt_present("skip_reg") {
+        for username in &["A. User", "A. Nother", "Dr. Who"] {
+            register_user(&mut manager, username, timeout_ms)
+        }
     }
 
     println!();
@@ -278,6 +319,11 @@ fn main() {
             Ok(StatusUpdate::PinUvError(e)) => {
                 panic!("Unexpected error: {:?}", e)
             }
+            Ok(StatusUpdate::SelectResultNotice(index_sender, users)) => {
+                println!("Multiple signatures returned. Select one or cancel.");
+                let idx = ask_user_choice(&users);
+                index_sender.send(idx).expect("Failed to send choice");
+            }
             Err(RecvError) => {
                 println!("STATUS: end");
                 return;
@@ -322,11 +368,7 @@ fn main() {
                 println!("Found credentials:");
                 println!(
                     "{:?}",
-                    assertion_object
-                        .assertions
-                        .iter()
-                        .map(|x| x.user.clone().unwrap().name.unwrap()) // Unwrapping here, as these shouldn't fail
-                        .collect::<Vec<_>>()
+                    assertion_object.assertion.user.clone().unwrap().name.unwrap() // Unwrapping here, as these shouldn't fail
                 );
                 println!("-----------------------------------------------------------------");
                 println!("Done.");

--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -7,8 +7,8 @@ use authenticator::{
     crypto::COSEAlgorithm,
     ctap2::server::{
         AuthenticationExtensionsClientInputs, PublicKeyCredentialDescriptor,
-        PublicKeyCredentialParameters, RelyingParty, ResidentKeyRequirement, Transport, User,
-        UserVerificationRequirement,
+        PublicKeyCredentialParameters, PublicKeyCredentialUserEntity, RelyingParty,
+        ResidentKeyRequirement, Transport, UserVerificationRequirement,
     },
     statecallback::StateCallback,
     Pin, StatusPinUv, StatusUpdate,
@@ -105,7 +105,7 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
         }
     });
 
-    let user = User {
+    let user = PublicKeyCredentialUserEntity {
         id: username.as_bytes().to_vec(),
         name: Some(username.to_string()),
         display_name: None,

--- a/examples/interactive_management.rs
+++ b/examples/interactive_management.rs
@@ -727,6 +727,9 @@ fn interactive_status_callback(status_rx: Receiver<StatusUpdate>) {
             Ok(StatusUpdate::PinUvError(e)) => {
                 panic!("Unexpected error: {:?}", e)
             }
+            Ok(StatusUpdate::SelectResultNotice(_, _)) => {
+                panic!("Unexpected select device notice")
+            }
             Err(RecvError) => {
                 println!("STATUS: end");
                 return;

--- a/examples/set_pin.rs
+++ b/examples/set_pin.rs
@@ -114,6 +114,9 @@ fn main() {
             Ok(StatusUpdate::PinUvError(e)) => {
                 panic!("Unexpected error: {:?}", e)
             }
+            Ok(StatusUpdate::SelectResultNotice(_, _)) => {
+                panic!("Unexpected select device notice")
+            }
             Err(RecvError) => {
                 println!("STATUS: end");
                 return;

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -7,8 +7,9 @@ use authenticator::{
     crypto::COSEAlgorithm,
     ctap2::commands::StatusCode,
     ctap2::server::{
-        PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
-        ResidentKeyRequirement, Transport, User, UserVerificationRequirement,
+        PublicKeyCredentialDescriptor, PublicKeyCredentialParameters,
+        PublicKeyCredentialUserEntity, RelyingParty, ResidentKeyRequirement, Transport,
+        UserVerificationRequirement,
     },
     errors::{AuthenticatorError, CommandError, HIDError, UnsupportedOption},
     statecallback::StateCallback,
@@ -134,7 +135,7 @@ fn main() {
         }
     });
 
-    let user = User {
+    let user = PublicKeyCredentialUserEntity {
         id: "user_id".as_bytes().to_vec(),
         name: Some("A. User".to_string()),
         display_name: None,

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -128,6 +128,9 @@ fn main() {
             Ok(StatusUpdate::PinUvError(e)) => {
                 panic!("Unexpected error: {:?}", e)
             }
+            Ok(StatusUpdate::SelectResultNotice(_, _)) => {
+                panic!("Unexpected select device notice")
+            }
             Err(RecvError) => {
                 println!("STATUS: end");
                 return;

--- a/src/authenticatorservice.rs
+++ b/src/authenticatorservice.rs
@@ -5,8 +5,8 @@
 use crate::ctap2::commands::client_pin::Pin;
 use crate::ctap2::server::{
     AuthenticationExtensionsClientInputs, PublicKeyCredentialDescriptor,
-    PublicKeyCredentialParameters, RelyingParty, ResidentKeyRequirement, User,
-    UserVerificationRequirement,
+    PublicKeyCredentialParameters, PublicKeyCredentialUserEntity, RelyingParty,
+    ResidentKeyRequirement, UserVerificationRequirement,
 };
 use crate::errors::*;
 use crate::manager::Manager;
@@ -18,7 +18,7 @@ pub struct RegisterArgs {
     pub client_data_hash: [u8; 32],
     pub relying_party: RelyingParty,
     pub origin: String,
-    pub user: User,
+    pub user: PublicKeyCredentialUserEntity,
     pub pub_cred_params: Vec<PublicKeyCredentialParameters>,
     pub exclude_list: Vec<PublicKeyCredentialDescriptor>,
     pub user_verification_req: UserVerificationRequirement,
@@ -318,7 +318,8 @@ mod tests {
     use super::{AuthenticatorService, AuthenticatorTransport, Pin, RegisterArgs, SignArgs};
     use crate::consts::PARAMETER_SIZE;
     use crate::ctap2::server::{
-        RelyingParty, ResidentKeyRequirement, User, UserVerificationRequirement,
+        PublicKeyCredentialUserEntity, RelyingParty, ResidentKeyRequirement,
+        UserVerificationRequirement,
     };
     use crate::errors::AuthenticatorError;
     use crate::statecallback::StateCallback;
@@ -439,7 +440,7 @@ mod tests {
                         name: None,
                     },
                     origin: "example.com".to_string(),
-                    user: User {
+                    user: PublicKeyCredentialUserEntity {
                         id: "user_id".as_bytes().to_vec(),
                         name: Some("A. User".to_string()),
                         display_name: None,
@@ -515,7 +516,7 @@ mod tests {
                         name: None,
                     },
                     origin: "example.com".to_string(),
-                    user: User {
+                    user: PublicKeyCredentialUserEntity {
                         id: "user_id".as_bytes().to_vec(),
                         name: Some("A. User".to_string()),
                         display_name: None,
@@ -610,7 +611,7 @@ mod tests {
                         name: None,
                     },
                     origin: "example.com".to_string(),
-                    user: User {
+                    user: PublicKeyCredentialUserEntity {
                         id: "user_id".as_bytes().to_vec(),
                         name: Some("A. User".to_string()),
                         display_name: None,

--- a/src/ctap2/commands/credential_management.rs
+++ b/src/ctap2/commands/credential_management.rs
@@ -2,7 +2,8 @@ use super::{Command, CommandError, PinUvAuthCommand, RequestCtap2, StatusCode};
 use crate::{
     crypto::{COSEKey, PinUvAuthParam, PinUvAuthToken},
     ctap2::server::{
-        PublicKeyCredentialDescriptor, RelyingParty, RpIdHash, User, UserVerificationRequirement,
+        PublicKeyCredentialDescriptor, PublicKeyCredentialUserEntity, RelyingParty, RpIdHash,
+        UserVerificationRequirement,
     },
     errors::AuthenticatorError,
     transport::errors::HIDError,
@@ -21,7 +22,7 @@ use std::fmt;
 struct CredManagementParams {
     rp_id_hash: Option<RpIdHash>, // RP ID SHA-256 hash
     credential_id: Option<PublicKeyCredentialDescriptor>, // Credential Identifier
-    user: Option<User>,           // User Entity
+    user: Option<PublicKeyCredentialUserEntity>, // User Entity
 }
 
 impl CredManagementParams {
@@ -68,7 +69,7 @@ pub(crate) enum CredManagementCommand {
     EnumerateCredentialsBegin(RpIdHash),
     EnumerateCredentialsGetNextCredential,
     DeleteCredential(PublicKeyCredentialDescriptor),
-    UpdateUserInformation((PublicKeyCredentialDescriptor, User)),
+    UpdateUserInformation((PublicKeyCredentialDescriptor, PublicKeyCredentialUserEntity)),
 }
 
 impl CredManagementCommand {
@@ -157,7 +158,7 @@ pub struct CredentialManagementResponse {
     /// Total number of RPs present on the authenticator
     pub total_rps: Option<u64>,
     /// User Information
-    pub user: Option<User>,
+    pub user: Option<PublicKeyCredentialUserEntity>,
     /// Credential ID
     pub credential_id: Option<PublicKeyCredentialDescriptor>,
     /// Public key of the credential.
@@ -182,7 +183,7 @@ pub struct CredentialRpListEntry {
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct CredentialListEntry {
     /// User Information
-    pub user: User,
+    pub user: PublicKeyCredentialUserEntity,
     /// Credential ID
     pub credential_id: PublicKeyCredentialDescriptor,
     /// Public key of the credential.

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -195,14 +195,10 @@ impl GetAssertion {
         // Handle extensions whose outputs are not encoded in the authenticator data.
         // 1. appId
         if let Some(app_id) = &self.extensions.app_id {
-            result.extensions.app_id = result
-                .assertions
-                .first()
-                .map(|assertion| {
-                    assertion.auth_data.rp_id_hash
-                        == RelyingPartyWrapper::from(app_id.as_str()).hash()
-                })
-                .or(Some(false));
+            result.extensions.app_id = Some(
+                result.assertion.auth_data.rp_id_hash
+                    == RelyingPartyWrapper::from(app_id.as_str()).hash(),
+            );
         }
     }
 }
@@ -307,7 +303,7 @@ impl Serialize for GetAssertion {
 }
 
 impl RequestCtap1 for GetAssertion {
-    type Output = GetAssertionResult;
+    type Output = Vec<GetAssertionResult>;
     type AdditionalInfo = PublicKeyCredentialDescriptor;
 
     fn ctap1_format(&self) -> Result<(Vec<u8>, Self::AdditionalInfo), HIDError> {
@@ -358,24 +354,27 @@ impl RequestCtap1 for GetAssertion {
             return Err(Retryable::Error(HIDError::ApduStatus(err)));
         }
 
-        let mut output = GetAssertionResult::from_ctap1(input, &self.rp.hash(), add_info)
+        let mut result = GetAssertionResult::from_ctap1(input, &self.rp.hash(), add_info)
             .map_err(|e| Retryable::Error(HIDError::Command(e)))?;
-        self.finalize_result(&mut output);
-        Ok(output)
+        self.finalize_result(&mut result);
+        // Although there's only one result, we return a vector for consistency with CTAP2.
+        Ok(vec![result])
     }
 
     fn send_to_virtual_device<Dev: VirtualFidoDevice>(
         &self,
         dev: &mut Dev,
     ) -> Result<Self::Output, HIDError> {
-        let mut output = dev.get_assertion(self)?;
-        self.finalize_result(&mut output);
-        Ok(output)
+        let mut results = dev.get_assertion(self)?;
+        for result in results.iter_mut() {
+            self.finalize_result(result);
+        }
+        Ok(results)
     }
 }
 
 impl RequestCtap2 for GetAssertion {
-    type Output = GetAssertionResult;
+    type Output = Vec<GetAssertionResult>;
 
     fn command(&self) -> Command {
         Command::GetAssertion
@@ -411,22 +410,27 @@ impl RequestCtap2 for GetAssertion {
             let assertion: GetAssertionResponse =
                 from_slice(&input[1..]).map_err(CommandError::Deserializing)?;
             let number_of_credentials = assertion.number_of_credentials.unwrap_or(1);
-            let mut assertions = Vec::with_capacity(number_of_credentials);
-            assertions.push(assertion.into());
+
+            let mut results = Vec::with_capacity(number_of_credentials);
+            results.push(GetAssertionResult {
+                assertion: assertion.into(),
+                extensions: Default::default(),
+            });
 
             let msg = GetNextAssertion;
             // We already have one, so skipping 0
             for _ in 1..number_of_credentials {
-                let new_cred = dev.send_cbor(&msg)?;
-                assertions.push(new_cred.into());
+                let assertion = dev.send_cbor(&msg)?;
+                results.push(GetAssertionResult {
+                    assertion: assertion.into(),
+                    extensions: Default::default(),
+                });
             }
 
-            let mut output = GetAssertionResult {
-                assertions,
-                extensions: Default::default(),
-            };
-            self.finalize_result(&mut output);
-            Ok(output)
+            for result in results.iter_mut() {
+                self.finalize_result(result);
+            }
+            Ok(results)
         } else {
             let data: Value = from_slice(&input[1..]).map_err(CommandError::Deserializing)?;
             Err(CommandError::StatusCode(status, Some(data)).into())
@@ -437,9 +441,11 @@ impl RequestCtap2 for GetAssertion {
         &self,
         dev: &mut Dev,
     ) -> Result<Self::Output, HIDError> {
-        let mut output = dev.get_assertion(self)?;
-        self.finalize_result(&mut output);
-        Ok(output)
+        let mut results = dev.get_assertion(self)?;
+        for result in results.iter_mut() {
+            self.finalize_result(result);
+        }
+        Ok(results)
     }
 }
 
@@ -465,7 +471,7 @@ impl From<GetAssertionResponse> for Assertion {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct GetAssertionResult {
-    pub assertions: Vec<Assertion>,
+    pub assertion: Assertion,
     pub extensions: AuthenticationExtensionsClientOutputs,
 }
 
@@ -501,22 +507,9 @@ impl GetAssertionResult {
         };
 
         Ok(GetAssertionResult {
-            assertions: vec![assertion],
+            assertion,
             extensions: Default::default(),
         })
-    }
-
-    pub fn u2f_sign_data(&self) -> Vec<u8> {
-        if let Some(first) = self.assertions.first() {
-            let mut res = Vec::new();
-            res.push(first.auth_data.flags.bits());
-            res.extend(first.auth_data.counter.to_be_bytes());
-            res.extend(&first.signature);
-            res
-            // first.signature.clone()
-        } else {
-            Vec::new()
-        }
     }
 }
 
@@ -791,10 +784,10 @@ pub mod test {
             auth_data: expected_auth_data,
         };
 
-        let expected = GetAssertionResult {
-            assertions: vec![expected_assertion],
+        let expected = vec![GetAssertionResult {
+            assertion: expected_assertion,
             extensions: Default::default(),
-        };
+        }];
         let response = device.send_cbor(&assertion).unwrap();
         assert_eq!(response, expected);
     }
@@ -926,10 +919,10 @@ pub mod test {
             auth_data: expected_auth_data,
         };
 
-        let expected = GetAssertionResult {
-            assertions: vec![expected_assertion],
+        let expected = vec![GetAssertionResult {
+            assertion: expected_assertion,
             extensions: Default::default(),
-        };
+        }];
         assert_eq!(response, expected);
     }
 
@@ -1070,10 +1063,10 @@ pub mod test {
             auth_data: expected_auth_data,
         };
 
-        let expected = GetAssertionResult {
-            assertions: vec![expected_assertion],
+        let expected = vec![GetAssertionResult {
+            assertion: expected_assertion,
             extensions: Default::default(),
-        };
+        }];
         assert_eq!(response, expected);
     }
 
@@ -1338,7 +1331,7 @@ pub mod test {
         let resp = GetAssertionResult::from_ctap1(&sample, &rp_hash, &add_info)
             .expect("could not handle response");
         assert_eq!(
-            resp.assertions[0].auth_data.flags,
+            resp.assertion.auth_data.flags,
             AuthenticatorDataFlags::USER_PRESENT | AuthenticatorDataFlags::RESERVED_1
         );
     }

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -13,7 +13,7 @@ use crate::ctap2::commands::get_next_assertion::GetNextAssertion;
 use crate::ctap2::commands::make_credentials::UserVerification;
 use crate::ctap2::server::{
     AuthenticationExtensionsClientInputs, AuthenticationExtensionsClientOutputs,
-    PublicKeyCredentialDescriptor, RelyingPartyWrapper, RpIdHash, User,
+    PublicKeyCredentialDescriptor, PublicKeyCredentialUserEntity, RelyingPartyWrapper, RpIdHash,
     UserVerificationRequirement,
 };
 use crate::ctap2::utils::{read_be_u32, read_byte};
@@ -449,7 +449,7 @@ pub struct Assertion {
                                                              * mandatory in CTAP2.1 */
     pub auth_data: AuthenticatorData,
     pub signature: Vec<u8>,
-    pub user: Option<User>,
+    pub user: Option<PublicKeyCredentialUserEntity>,
 }
 
 impl From<GetAssertionResponse> for Assertion {
@@ -524,7 +524,7 @@ pub struct GetAssertionResponse {
     pub credentials: Option<PublicKeyCredentialDescriptor>,
     pub auth_data: AuthenticatorData,
     pub signature: Vec<u8>,
-    pub user: Option<User>,
+    pub user: Option<PublicKeyCredentialUserEntity>,
     pub number_of_credentials: Option<usize>,
 }
 
@@ -628,7 +628,8 @@ pub mod test {
         do_credential_list_filtering_ctap1, do_credential_list_filtering_ctap2,
     };
     use crate::ctap2::server::{
-        PublicKeyCredentialDescriptor, RelyingParty, RelyingPartyWrapper, RpIdHash, Transport, User,
+        PublicKeyCredentialDescriptor, PublicKeyCredentialUserEntity, RelyingParty,
+        RelyingPartyWrapper, RpIdHash, Transport,
     };
     use crate::transport::device_selector::Device;
     use crate::transport::hid::HIDDevice;
@@ -778,7 +779,7 @@ pub mod test {
                 0x47, 0xf1, 0x8d, 0xb4, 0x74, 0xc7, 0x47, 0x90, 0xea, 0xab, 0xb1, 0x44, 0x11, 0xe7,
                 0xa0,
             ],
-            user: Some(User {
+            user: Some(PublicKeyCredentialUserEntity {
                 id: vec![
                     0x30, 0x82, 0x01, 0x93, 0x30, 0x82, 0x01, 0x38, 0xa0, 0x03, 0x02, 0x01, 0x02,
                     0x30, 0x82, 0x01, 0x93, 0x30, 0x82, 0x01, 0x38, 0xa0, 0x03, 0x02, 0x01, 0x02,

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -15,7 +15,8 @@ use crate::ctap2::client_data::ClientDataHash;
 use crate::ctap2::server::{
     AuthenticationExtensionsClientInputs, AuthenticationExtensionsClientOutputs,
     CredentialProtectionPolicy, PublicKeyCredentialDescriptor, PublicKeyCredentialParameters,
-    RelyingParty, RelyingPartyWrapper, RpIdHash, User, UserVerificationRequirement,
+    PublicKeyCredentialUserEntity, RelyingParty, RelyingPartyWrapper, RpIdHash,
+    UserVerificationRequirement,
 };
 use crate::ctap2::utils::{read_byte, serde_parse_err};
 use crate::errors::AuthenticatorError;
@@ -260,7 +261,7 @@ pub struct MakeCredentials {
     pub client_data_hash: ClientDataHash,
     pub rp: RelyingPartyWrapper,
     // Note(baloo): If none -> ctap1
-    pub user: Option<User>,
+    pub user: Option<PublicKeyCredentialUserEntity>,
     pub pub_cred_params: Vec<PublicKeyCredentialParameters>,
     pub exclude_list: Vec<PublicKeyCredentialDescriptor>,
 
@@ -281,7 +282,7 @@ impl MakeCredentials {
     pub fn new(
         client_data_hash: ClientDataHash,
         rp: RelyingPartyWrapper,
-        user: Option<User>,
+        user: Option<PublicKeyCredentialUserEntity>,
         pub_cred_params: Vec<PublicKeyCredentialParameters>,
         exclude_list: Vec<PublicKeyCredentialDescriptor>,
         options: MakeCredentialsOptions,
@@ -564,7 +565,7 @@ pub(crate) fn dummy_make_credentials_cmd() -> MakeCredentials {
             id: String::from("make.me.blink"),
             ..Default::default()
         }),
-        Some(User {
+        Some(PublicKeyCredentialUserEntity {
             id: vec![0],
             name: Some(String::from("make.me.blink")),
             ..Default::default()
@@ -597,7 +598,8 @@ pub mod test {
     use crate::ctap2::commands::{RequestCtap1, RequestCtap2};
     use crate::ctap2::server::RpIdHash;
     use crate::ctap2::server::{
-        PublicKeyCredentialParameters, RelyingParty, RelyingPartyWrapper, User,
+        PublicKeyCredentialParameters, PublicKeyCredentialUserEntity, RelyingParty,
+        RelyingPartyWrapper,
     };
     use crate::transport::device_selector::Device;
     use crate::transport::hid::HIDDevice;
@@ -620,7 +622,7 @@ pub mod test {
                 id: String::from("example.com"),
                 name: Some(String::from("Acme")),
             }),
-            Some(User {
+            Some(PublicKeyCredentialUserEntity {
                 id: base64::engine::general_purpose::URL_SAFE
                     .decode("MIIBkzCCATigAwIBAjCCAZMwggE4oAMCAQIwggGTMII=")
                     .unwrap(),
@@ -677,7 +679,7 @@ pub mod test {
                 id: String::from("example.com"),
                 name: Some(String::from("Acme")),
             }),
-            Some(User {
+            Some(PublicKeyCredentialUserEntity {
                 id: base64::engine::general_purpose::URL_SAFE
                     .decode("MIIBkzCCATigAwIBAjCCAZMwggE4oAMCAQIwggGTMII=")
                     .unwrap(),

--- a/src/ctap2/preflight.rs
+++ b/src/ctap2/preflight.rs
@@ -161,13 +161,12 @@ pub(crate) fn do_credential_list_filtering_ctap2<Dev: FidoDevice>(
         );
         silent_assert.set_pin_uv_auth_param(pin_uv_auth_token.clone())?;
         match dev.send_msg(&silent_assert) {
-            Ok(response) => {
+            Ok(mut response) => {
                 // This chunk contains a key_handle that is already known to the device.
                 // Filter out all credentials the device returned. Those are valid.
                 let credential_ids = response
-                    .assertions
-                    .iter()
-                    .filter_map(|a| a.credentials.clone())
+                    .iter_mut()
+                    .filter_map(|result| result.assertion.credentials.take())
                     .collect();
                 // Replace credential_id_list with the valid credentials
                 final_list = credential_ids;

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -40,12 +40,9 @@ impl RpIdHash {
     }
 }
 
+// NOTE: WebAuthn requires all fields and CTAP2 does not.
 #[derive(Debug, Serialize, Clone, Default, Deserialize, PartialEq, Eq)]
 pub struct RelyingParty {
-    // TODO(baloo): spec is wrong !!!!111
-    //              https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#commands
-    //              in the example "A PublicKeyCredentialRpEntity DOM object defined as follows:"
-    //              inconsistent with https://w3c.github.io/webauthn/#sctn-rp-credential-params
     pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -94,9 +91,9 @@ impl RelyingPartyWrapper {
     }
 }
 
-// TODO(baloo): should we rename this PublicKeyCredentialUserEntity ?
+// NOTE: WebAuthn requires all fields and CTAP2 does not.
 #[derive(Debug, Serialize, Clone, Eq, PartialEq, Deserialize, Default)]
-pub struct User {
+pub struct PublicKeyCredentialUserEntity {
     #[serde(with = "serde_bytes")]
     pub id: Vec<u8>,
     pub name: Option<String>,
@@ -406,13 +403,13 @@ pub struct AuthenticationExtensionsClientOutputs {
 #[cfg(test)]
 mod test {
     use super::{
-        COSEAlgorithm, PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty,
-        Transport, User,
+        COSEAlgorithm, PublicKeyCredentialDescriptor, PublicKeyCredentialParameters,
+        PublicKeyCredentialUserEntity, RelyingParty, Transport,
     };
     use serde_cbor::from_slice;
 
-    fn create_user() -> User {
-        User {
+    fn create_user() -> PublicKeyCredentialUserEntity {
+        PublicKeyCredentialUserEntity {
             id: vec![
                 0x30, 0x82, 0x01, 0x93, 0x30, 0x82, 0x01, 0x38, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x30,
                 0x82, 0x01, 0x93, 0x30, 0x82, 0x01, 0x38, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x30, 0x82,
@@ -479,7 +476,7 @@ mod test {
             0x69, 0x74, 0x68, // ...
         ];
         let expected = create_user();
-        let actual: User = from_slice(&input).unwrap();
+        let actual: PublicKeyCredentialUserEntity = from_slice(&input).unwrap();
         assert_eq!(expected, actual);
     }
 
@@ -519,7 +516,7 @@ mod test {
 
     #[test]
     fn serialize_user_nodisplayname() {
-        let user = User {
+        let user = PublicKeyCredentialUserEntity {
             id: vec![
                 0x30, 0x82, 0x01, 0x93, 0x30, 0x82, 0x01, 0x38, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x30,
                 0x82, 0x01, 0x93, 0x30, 0x82, 0x01, 0x38, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x30, 0x82,

--- a/src/status_update.rs
+++ b/src/status_update.rs
@@ -7,7 +7,7 @@ use crate::{
             get_info::AuthenticatorInfo,
             PinUvAuthResult,
         },
-        server::{PublicKeyCredentialDescriptor, User},
+        server::{PublicKeyCredentialDescriptor, PublicKeyCredentialUserEntity},
     },
     BioEnrollmentResult, CredentialManagementResult,
 };
@@ -18,7 +18,7 @@ use std::sync::mpsc::Sender;
 pub enum CredManagementCmd {
     GetCredentials,
     DeleteCredential(PublicKeyCredentialDescriptor),
-    UpdateUserInformation(PublicKeyCredentialDescriptor, User),
+    UpdateUserInformation(PublicKeyCredentialDescriptor, PublicKeyCredentialUserEntity),
 }
 
 #[derive(Debug, Deserialize, DeriveSer)]

--- a/src/status_update.rs
+++ b/src/status_update.rs
@@ -105,6 +105,8 @@ pub enum StatusUpdate {
     SelectDeviceNotice,
     /// Sent when a token was selected for interactive management
     InteractiveManagement(InteractiveUpdate),
+    /// Sent when a token returns multiple results for a getAssertion request
+    SelectResultNotice(Sender<Option<usize>>, Vec<PublicKeyCredentialUserEntity>),
 }
 
 pub(crate) fn send_status(status: &Sender<StatusUpdate>, msg: StatusUpdate) {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -345,7 +345,7 @@ where
 pub trait VirtualFidoDevice: FidoDevice {
     fn check_key_handle(&self, req: &CheckKeyHandle) -> Result<(), HIDError>;
     fn client_pin(&self, req: &ClientPIN) -> Result<ClientPinResponse, HIDError>;
-    fn get_assertion(&self, req: &GetAssertion) -> Result<GetAssertionResult, HIDError>;
+    fn get_assertion(&self, req: &GetAssertion) -> Result<Vec<GetAssertionResult>, HIDError>;
     fn get_info(&self) -> Result<AuthenticatorInfo, HIDError>;
     fn get_version(&self, req: &GetVersion) -> Result<U2FInfo, HIDError>;
     fn make_credentials(&self, req: &MakeCredentials) -> Result<MakeCredentialsResult, HIDError>;


### PR DESCRIPTION
When an `authenticatorGetAssertion` response includes more than one credential, we present the user with a list of the associated usernames and ask them to select one. Their choice determines which credential is returned to the RP. Firefox currently handles this "in the WebAuthn layer" as follows:

1) authenticator-rs receives a `authenticatorGetAssertion` response and repackages it into a `GetAssertionResult` that it returns to authrs_bridge.
2) authrs_bridge returns (an XPCOM wrapper around) this `GetAssertionResult` to WebAuthnController.
2) WebAuthnController reads user names out of the `Assertion`s and shows a selection prompt.
3) the prompt calls back to WebAuthnController with the selection result.
4) WebAuthnController constructs a `WebAuthnGetAssertionResult` IPC message based on the selected Assertion and returns it to the client process.

We're planning to refactor the `WebAuthnController` ↔ `authrs_bridge` boundary so that `WebAuthnController` will be solely responsible for IPC. That means all of the prompt generation logic needs to move into `authrs_bridge`.

This PR changes `GetAssertionResult` from
```rust
pub struct GetAssertionResult {
    pub assertions: Vec<Assertion>,
    pub extensions: AuthenticationExtensionsClientOutputs,
}
```
to
```rust
pub struct GetAssertionResult {
    pub assertion: Assertion,
    pub extensions: AuthenticationExtensionsClientOutputs,
}
```
And it adds 
```rust
enum StatusUpdate {
    [...]
    SelectResultNotice(Sender<Option<usize>>, Vec<PublicKeyCredentialUserEntity>)
}
```
The new flow will be
1) authenticator-rs receives an `authenticatorGetAssertion` response and sends a `SelectResultNotice` to the authrs_bridge's status update handler.
2) authrs_bridge  shows a selection prompt.
3) the prompt calls back to authrs_bridge with the selection result, which authrs_bridge forwards to authenticator-rs.
4) authenticator-rs repackages the appropriate response into a `GetAssertionResult` which it returns to authrs_bridge.
5) authrs_bridge returns the (wrapped) result to WebAuthnController.

In addition to facilitating our IPC-focused refactor of WebAuthnController, this also unblocks some work on get() extensions.