### PR TITLE
Allow extension processing to depend on device info

### DIFF
--- a/src/ctap2/commands/get_version.rs
+++ b/src/ctap2/commands/get_version.rs
@@ -1,7 +1,7 @@
 use super::{CommandError, RequestCtap1, Retryable};
 use crate::consts::U2F_VERSION;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
-use crate::transport::VirtualFidoDevice;
+use crate::transport::{FidoDevice, VirtualFidoDevice};
 use crate::u2ftypes::CTAP1RequestAPDU;
 
 #[allow(non_camel_case_types)]
@@ -18,8 +18,9 @@ impl RequestCtap1 for GetVersion {
     type Output = U2FInfo;
     type AdditionalInfo = ();
 
-    fn handle_response_ctap1(
+    fn handle_response_ctap1<Dev: FidoDevice>(
         &self,
+        _dev: &mut Dev,
         _status: Result<(), ApduErrorStatus>,
         input: &[u8],
         _add_info: &(),

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -60,8 +60,9 @@ pub trait RequestCtap1: fmt::Debug {
     fn ctap1_format(&self) -> Result<(Vec<u8>, Self::AdditionalInfo), HIDError>;
 
     /// Deserializes a response from FIDO v1.x / CTAP1 / U2Fv2 format.
-    fn handle_response_ctap1(
+    fn handle_response_ctap1<Dev: FidoDevice>(
         &self,
+        dev: &mut Dev,
         status: Result<(), ApduErrorStatus>,
         input: &[u8],
         add_info: &Self::AdditionalInfo,

--- a/src/ctap2/preflight.rs
+++ b/src/ctap2/preflight.rs
@@ -44,8 +44,9 @@ impl<'assertion> RequestCtap1 for CheckKeyHandle<'assertion> {
         Ok((apdu, ()))
     }
 
-    fn handle_response_ctap1(
+    fn handle_response_ctap1<Dev: FidoDevice>(
         &self,
+        _dev: &mut Dev,
         status: Result<(), ApduErrorStatus>,
         _input: &[u8],
         _add_info: &Self::AdditionalInfo,

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -379,6 +379,13 @@ pub struct AuthenticationExtensionsClientOutputs {
     pub hmac_create_secret: Option<bool>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AuthenticatorAttachment {
+    CrossPlatform,
+    Platform,
+    Unknown,
+}
+
 #[cfg(test)]
 mod test {
     use super::{

--- a/src/transport/hid.rs
+++ b/src/transport/hid.rs
@@ -215,7 +215,7 @@ impl<T: HIDDevice> FidoDeviceIO for T {
                 // This will bubble up error if status != no error
                 let status = ApduErrorStatus::from([status[0], status[1]]);
 
-                match msg.handle_response_ctap1(status, &data, &add_info) {
+                match msg.handle_response_ctap1(self, status, &data, &add_info) {
                     Ok(out) => return Ok(out),
                     Err(Retryable::Retry) => {
                         // sleep 100ms then loop again


### PR DESCRIPTION
Some extensions need information from the `FidoDevice` that handled the request. For example, the hmac-secret extension uses the device <-> client shared secret. This PR adds a device input to `finalize_result`. I've also updated our credProps support to handle a quirk wrt CTAP 2.0 devices. (There's a wpt to check for the quirk handling that [Firefox currently fails](https://wpt.fyi/results/webauthn/createcredential-resident-key.https.html?run_id=5161589633712128&run_id=6318289891885056&run_id=5169812390543360&run_id=5126979914825728)). And I've added an `AuthenticatorAttachment` field to results that indicates whether or not the response came from a platform authenticator.