### PR TITLE
Fix #319: CTAP2.0 bug in preflighting, which can omit credential data

### DIFF
--- a/src/ctap2/commands/bio_enrollment.rs
+++ b/src/ctap2/commands/bio_enrollment.rs
@@ -14,7 +14,7 @@ use serde_bytes::ByteBuf;
 use serde_cbor::{from_slice, to_vec, Value};
 use std::fmt;
 
-use super::{Command, CommandError, PinUvAuthCommand, RequestCtap2, StatusCode};
+use super::{Command, CommandError, CtapResponse, PinUvAuthCommand, RequestCtap2, StatusCode};
 
 #[derive(Debug, Clone, Copy)]
 pub enum BioEnrollmentModality {
@@ -517,6 +517,8 @@ pub struct BioEnrollmentResponse {
     /// Indicates the maximum number of bytes the authenticator will accept as a templateFriendlyName.
     pub(crate) max_template_friendly_name: Option<u64>,
 }
+
+impl CtapResponse for BioEnrollmentResponse {}
 
 impl<'de> Deserialize<'de> for BioEnrollmentResponse {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/ctap2/commands/client_pin.rs
+++ b/src/ctap2/commands/client_pin.rs
@@ -1,4 +1,5 @@
 #![allow(non_upper_case_globals)]
+use super::CtapResponse;
 // Note: Needed for PinUvAuthTokenPermission
 //       The current version of `bitflags` doesn't seem to allow
 //       to set this for an individual bitflag-struct.
@@ -154,6 +155,8 @@ pub struct ClientPinResponse {
     pub power_cycle_state: Option<bool>,
     pub uv_retries: Option<u8>,
 }
+
+impl CtapResponse for ClientPinResponse {}
 
 impl<'de> Deserialize<'de> for ClientPinResponse {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/ctap2/commands/credential_management.rs
+++ b/src/ctap2/commands/credential_management.rs
@@ -1,4 +1,4 @@
-use super::{Command, CommandError, PinUvAuthCommand, RequestCtap2, StatusCode};
+use super::{Command, CommandError, CtapResponse, PinUvAuthCommand, RequestCtap2, StatusCode};
 use crate::{
     crypto::{COSEKey, PinUvAuthParam, PinUvAuthToken},
     ctap2::server::{
@@ -170,6 +170,8 @@ pub struct CredentialManagementResponse {
     /// Large blob encryption key.
     pub large_blob_key: Option<Vec<u8>>,
 }
+
+impl CtapResponse for CredentialManagementResponse {}
 
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct CredentialRpListEntry {

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -1,6 +1,7 @@
 use super::get_info::AuthenticatorInfo;
 use super::{
-    Command, CommandError, PinUvAuthCommand, RequestCtap1, RequestCtap2, Retryable, StatusCode,
+    Command, CommandError, CtapResponse, PinUvAuthCommand, RequestCtap1, RequestCtap2, Retryable,
+    StatusCode,
 };
 use crate::consts::{
     PARAMETER_SIZE, U2F_AUTHENTICATE, U2F_DONT_ENFORCE_USER_PRESENCE_AND_SIGN,
@@ -292,6 +293,9 @@ impl Serialize for GetAssertion {
     }
 }
 
+type GetAssertionOutput = Vec<GetAssertionResult>;
+impl CtapResponse for GetAssertionOutput {}
+
 impl RequestCtap1 for GetAssertion {
     type Output = Vec<GetAssertionResult>;
     type AdditionalInfo = PublicKeyCredentialDescriptor;
@@ -508,6 +512,7 @@ impl GetAssertionResult {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct GetAssertionResponse {
     pub credentials: Option<PublicKeyCredentialDescriptor>,
     pub auth_data: AuthenticatorData,
@@ -515,6 +520,8 @@ pub struct GetAssertionResponse {
     pub user: Option<PublicKeyCredentialUserEntity>,
     pub number_of_credentials: Option<usize>,
 }
+
+impl CtapResponse for GetAssertionResponse {}
 
 impl<'de> Deserialize<'de> for GetAssertionResponse {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -1,4 +1,4 @@
-use super::{Command, CommandError, RequestCtap2, StatusCode};
+use super::{Command, CommandError, CtapResponse, RequestCtap2, StatusCode};
 use crate::ctap2::attestation::AAGuid;
 use crate::ctap2::server::PublicKeyCredentialParameters;
 use crate::transport::errors::HIDError;
@@ -367,6 +367,8 @@ impl AuthenticatorInfo {
         self.options.client_pin == Some(true) || self.options.user_verification == Some(true)
     }
 }
+
+impl CtapResponse for AuthenticatorInfo {}
 
 macro_rules! parse_next_optional_value {
     ($name:expr, $map:expr) => {

--- a/src/ctap2/commands/get_version.rs
+++ b/src/ctap2/commands/get_version.rs
@@ -1,13 +1,16 @@
-use super::{CommandError, RequestCtap1, Retryable};
+use super::{CommandError, CtapResponse, RequestCtap1, Retryable};
 use crate::consts::U2F_VERSION;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
 use crate::transport::{FidoDevice, VirtualFidoDevice};
 use crate::u2ftypes::CTAP1RequestAPDU;
 
 #[allow(non_camel_case_types)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum U2FInfo {
     U2F_V2,
 }
+
+impl CtapResponse for U2FInfo {}
 
 #[derive(Debug, Default)]
 // TODO(baloo): if one does not issue U2F_VERSION before makecredentials or getassertion, token

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -1,6 +1,7 @@
 use super::get_info::{AuthenticatorInfo, AuthenticatorVersion};
 use super::{
-    Command, CommandError, PinUvAuthCommand, RequestCtap1, RequestCtap2, Retryable, StatusCode,
+    Command, CommandError, CtapResponse, PinUvAuthCommand, RequestCtap1, RequestCtap2, Retryable,
+    StatusCode,
 };
 use crate::consts::{PARAMETER_SIZE, U2F_REGISTER, U2F_REQUEST_USER_PRESENCE};
 use crate::crypto::{
@@ -198,6 +199,8 @@ impl<'de> Deserialize<'de> for MakeCredentialsResult {
         deserializer.deserialize_bytes(MakeCredentialsResultVisitor)
     }
 }
+
+impl CtapResponse for MakeCredentialsResult {}
 
 #[derive(Copy, Clone, Debug, Default, Serialize)]
 #[cfg_attr(test, derive(Deserialize))]

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -1,7 +1,5 @@
 use crate::crypto::{CryptoError, PinUvAuthParam, PinUvAuthToken};
-use crate::ctap2::commands::client_pin::{
-    GetPinRetries, GetUvRetries, PinError,
-};
+use crate::ctap2::commands::client_pin::{GetPinRetries, GetUvRetries, PinError};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::ctap2::server::UserVerificationRequirement;
 use crate::errors::AuthenticatorError;
@@ -50,7 +48,7 @@ impl<T> From<T> for Retryable<T> {
 }
 
 pub trait RequestCtap1: fmt::Debug {
-    type Output;
+    type Output: CtapResponse;
     // E.g.: For GetAssertion, which key-handle is currently being tested
     type AdditionalInfo;
 
@@ -75,7 +73,7 @@ pub trait RequestCtap1: fmt::Debug {
 }
 
 pub trait RequestCtap2: fmt::Debug {
-    type Output;
+    type Output: CtapResponse;
 
     fn command(&self) -> Command;
 
@@ -92,6 +90,10 @@ pub trait RequestCtap2: fmt::Debug {
         dev: &mut Dev,
     ) -> Result<Self::Output, HIDError>;
 }
+
+// Sadly, needs to be 'static to enable us in tests to collect them in a Vec
+// but all of them are 'static, so this is currently no problem.
+pub trait CtapResponse: std::fmt::Debug + 'static {}
 
 #[derive(Debug, Clone)]
 pub enum PinUvAuthResult {

--- a/src/ctap2/preflight.rs
+++ b/src/ctap2/preflight.rs
@@ -1,6 +1,6 @@
 use super::client_data::ClientDataHash;
 use super::commands::get_assertion::{GetAssertion, GetAssertionExtensions, GetAssertionOptions};
-use super::commands::{PinUvAuthCommand, RequestCtap1, Retryable};
+use super::commands::{CtapResponse, PinUvAuthCommand, RequestCtap1, Retryable};
 use crate::consts::{PARAMETER_SIZE, U2F_AUTHENTICATE, U2F_CHECK_IS_REGISTERED};
 use crate::crypto::PinUvAuthToken;
 use crate::ctap2::server::{PublicKeyCredentialDescriptor, RelyingParty};
@@ -22,8 +22,11 @@ pub struct CheckKeyHandle<'assertion> {
     pub rp: &'assertion RelyingParty,
 }
 
+type EmptyResponse = ();
+impl CtapResponse for EmptyResponse {}
+
 impl<'assertion> RequestCtap1 for CheckKeyHandle<'assertion> {
-    type Output = ();
+    type Output = EmptyResponse;
     type AdditionalInfo = ();
 
     fn ctap1_format(&self) -> Result<(Vec<u8>, Self::AdditionalInfo), HIDError> {
@@ -167,7 +170,16 @@ pub(crate) fn do_credential_list_filtering_ctap2<Dev: FidoDevice>(
                 // Filter out all credentials the device returned. Those are valid.
                 let credential_ids = response
                     .iter_mut()
-                    .filter_map(|result| result.assertion.credentials.take())
+                    .filter_map(|result| {
+                        // CTAP 2.0 devices can omit the credentials in their response,
+                        // if the given allowList was only 1 entry long. If so, we have
+                        // to fill it in ourselfs.
+                        if chunk.len() == 1 && result.assertion.credentials.is_none() {
+                            Some(chunk[0].clone())
+                        } else {
+                            result.assertion.credentials.take()
+                        }
+                    })
                     .collect();
                 // Replace credential_id_list with the valid credentials
                 final_list = credential_ids;
@@ -204,4 +216,315 @@ pub(crate) fn silently_discover_credentials<Dev: FidoDevice>(
         return vec![key_handle];
     }
     vec![]
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::{
+        crypto::{COSEAlgorithm, COSEEC2Key, COSEKey, COSEKeyType, Curve},
+        ctap2::{
+            attestation::{
+                AAGuid, AttestedCredentialData, AuthenticatorData, AuthenticatorDataFlags,
+                Extension,
+            },
+            commands::{CommandError, StatusCode},
+            server::{AuthenticationExtensionsClientOutputs, AuthenticatorAttachment, Transport},
+        },
+        transport::{
+            device_selector::tests::{make_device_simple_u2f, make_device_with_pin},
+            hid::HIDDevice,
+            platform::device::Device,
+        },
+        Assertion, GetAssertionResult,
+    };
+
+    fn new_relying_party(name: &str) -> RelyingParty {
+        RelyingParty {
+            id: String::from(name),
+            name: Some(String::from(name)),
+        }
+    }
+
+    fn new_silent_assert(
+        rp: &RelyingParty,
+        allow_list: &[PublicKeyCredentialDescriptor],
+    ) -> GetAssertion {
+        GetAssertion::new(
+            ClientDataHash(Sha256::digest("").into()),
+            rp.clone(),
+            allow_list.to_vec(),
+            GetAssertionOptions {
+                user_verification: None, // defaults to Some(false) if puap is absent
+                user_presence: Some(false),
+            },
+            GetAssertionExtensions::default(),
+        )
+    }
+
+    fn new_credential(fill: u8, repeat: usize) -> PublicKeyCredentialDescriptor {
+        PublicKeyCredentialDescriptor {
+            id: vec![fill; repeat],
+            transports: vec![Transport::USB],
+        }
+    }
+
+    fn new_assertion_response(
+        rp: &RelyingParty,
+        cred: Option<&PublicKeyCredentialDescriptor>,
+    ) -> GetAssertionResult {
+        let credential_data = cred.map(|cred| AttestedCredentialData {
+            aaguid: AAGuid::default(),
+            credential_id: cred.id.clone(),
+            credential_public_key: COSEKey {
+                alg: COSEAlgorithm::RS256,
+                key: COSEKeyType::EC2(COSEEC2Key {
+                    curve: Curve::SECP256R1,
+                    x: vec![],
+                    y: vec![],
+                }),
+            },
+        });
+        GetAssertionResult {
+            assertion: Assertion {
+                credentials: cred.cloned(),
+                auth_data: AuthenticatorData {
+                    rp_id_hash: rp.hash(),
+                    flags: AuthenticatorDataFlags::empty(),
+                    counter: 0,
+                    credential_data,
+                    extensions: Extension::default(),
+                },
+                signature: vec![],
+                user: None,
+            },
+            attachment: AuthenticatorAttachment::Platform,
+            extensions: AuthenticationExtensionsClientOutputs::default(),
+        }
+    }
+
+    fn new_check_key_handle<'a>(
+        rp: &'a RelyingParty,
+        client_data_hash: &'a ClientDataHash,
+        cred: &'a PublicKeyCredentialDescriptor,
+    ) -> CheckKeyHandle<'a> {
+        CheckKeyHandle {
+            key_handle: cred.id.as_ref(),
+            client_data_hash: client_data_hash.as_ref(),
+            rp,
+        }
+    }
+
+    #[test]
+    fn test_preflight_ctap1_empty() {
+        let mut dev = Device::new("preflight").unwrap();
+        make_device_simple_u2f(&mut dev);
+        let client_data_hash = ClientDataHash(Sha256::digest("").into());
+        let rp = new_relying_party("preflight test");
+        let res = silently_discover_credentials(&mut dev, &[], &rp, &client_data_hash);
+        assert!(res.is_empty());
+    }
+
+    #[test]
+    fn test_preflight_ctap1_multiple_replies() {
+        let mut dev = Device::new_skipping_serialization("preflight").unwrap();
+        make_device_simple_u2f(&mut dev);
+        let rp = new_relying_party("preflight test");
+        let cdh = ClientDataHash(Sha256::digest("").into());
+        let allow_list = vec![
+            new_credential(4, 4),
+            new_credential(3, 4),
+            new_credential(2, 4),
+            new_credential(1, 4),
+        ];
+        dev.add_upcoming_ctap1_request(&new_check_key_handle(&rp, &cdh, &allow_list[0]));
+        dev.add_upcoming_ctap_error(HIDError::ApduStatus(
+            ApduErrorStatus::WrongData, // Not a registered cred
+        ));
+        dev.add_upcoming_ctap1_request(&new_check_key_handle(&rp, &cdh, &allow_list[1]));
+        dev.add_upcoming_ctap_error(HIDError::ApduStatus(
+            ApduErrorStatus::WrongData, // Not a registered cred
+        ));
+        dev.add_upcoming_ctap1_request(&new_check_key_handle(&rp, &cdh, &allow_list[2]));
+        dev.add_upcoming_ctap_response(()); // Valid credential - the code exits here now and doesn't even look at the last one
+
+        let res = silently_discover_credentials(&mut dev, &allow_list, &rp, &cdh);
+        assert_eq!(res, vec![allow_list[2].clone()]);
+    }
+
+    #[test]
+    fn test_preflight_ctap1_too_long_entries() {
+        let mut dev = Device::new_skipping_serialization("preflight").unwrap();
+        make_device_simple_u2f(&mut dev);
+        let rp = new_relying_party("preflight test");
+        let cdh = ClientDataHash(Sha256::digest("").into());
+        let allow_list = vec![
+            new_credential(4, 300), // ctap1 limit is 256
+            new_credential(3, 4),
+            new_credential(2, 4),
+            new_credential(1, 4),
+        ];
+        // allow_list[0] is filtered out due to its size
+        dev.add_upcoming_ctap1_request(&new_check_key_handle(&rp, &cdh, &allow_list[1]));
+        dev.add_upcoming_ctap_error(HIDError::ApduStatus(
+            ApduErrorStatus::WrongData, // Not a registered cred
+        ));
+        dev.add_upcoming_ctap1_request(&new_check_key_handle(&rp, &cdh, &allow_list[2]));
+        dev.add_upcoming_ctap_response(()); // Valid credential - the code exits here now and doesn't even look at the last one
+
+        let res = silently_discover_credentials(&mut dev, &allow_list, &rp, &cdh);
+        assert_eq!(res, vec![allow_list[2].clone()]);
+    }
+
+    #[test]
+    fn test_preflight_ctap2_empty() {
+        let mut dev = Device::new("preflight").unwrap();
+        make_device_with_pin(&mut dev);
+        let rp = new_relying_party("preflight test");
+        let client_data_hash = ClientDataHash(Sha256::digest("").into());
+        let res = silently_discover_credentials(&mut dev, &[], &rp, &client_data_hash);
+        assert!(res.is_empty());
+    }
+
+    #[test]
+    fn test_preflight_ctap20_no_cred_data() {
+        // CTAP2.0 tokens are allowed to not send any credential-data in their
+        // response, if the allow-list is of length one. See https://github.com/mozilla/authenticator-rs/issues/319
+        let mut dev = Device::new_skipping_serialization("preflight").unwrap();
+        make_device_with_pin(&mut dev);
+        let rp = new_relying_party("preflight test");
+        let client_data_hash = ClientDataHash(Sha256::digest("").into());
+        let allow_list = vec![new_credential(1, 4)];
+        dev.add_upcoming_ctap2_request(&new_silent_assert(&rp, &allow_list));
+        dev.add_upcoming_ctap_response(vec![new_assertion_response(&rp, None)]);
+        let res = silently_discover_credentials(&mut dev, &allow_list, &rp, &client_data_hash);
+        assert_eq!(res, allow_list);
+    }
+
+    #[test]
+    fn test_preflight_ctap2_one_valid_entry() {
+        let mut dev = Device::new_skipping_serialization("preflight").unwrap();
+        make_device_with_pin(&mut dev);
+        let rp = new_relying_party("preflight test");
+        let client_data_hash = ClientDataHash(Sha256::digest("").into());
+        let allow_list = vec![new_credential(1, 4)];
+        dev.add_upcoming_ctap2_request(&new_silent_assert(&rp, &allow_list));
+        dev.add_upcoming_ctap_response(vec![new_assertion_response(&rp, Some(&allow_list[0]))]);
+        let res = silently_discover_credentials(&mut dev, &allow_list, &rp, &client_data_hash);
+        assert_eq!(res, allow_list);
+    }
+
+    #[test]
+    fn test_preflight_ctap2_multiple_entries() {
+        let mut dev = Device::new_skipping_serialization("preflight").unwrap();
+        make_device_with_pin(&mut dev);
+        let rp = new_relying_party("preflight test");
+        let client_data_hash = ClientDataHash(Sha256::digest("").into());
+        let allow_list = vec![
+            new_credential(3, 4),
+            new_credential(2, 4),
+            new_credential(1, 4),
+            new_credential(0, 4),
+        ];
+        // Our test device doesn't say how many allow_list-entries it supports, so our code
+        // defaults to one. Thus three requests, with three answers. Only one of them
+        // valid.
+        dev.add_upcoming_ctap2_request(&new_silent_assert(&rp, &[allow_list[0].clone()]));
+        dev.add_upcoming_ctap2_request(&new_silent_assert(&rp, &[allow_list[1].clone()]));
+        dev.add_upcoming_ctap2_request(&new_silent_assert(&rp, &[allow_list[2].clone()]));
+        dev.add_upcoming_ctap_error(HIDError::Command(CommandError::StatusCode(
+            StatusCode::NoCredentials,
+            None,
+        )));
+        dev.add_upcoming_ctap_error(HIDError::Command(CommandError::StatusCode(
+            StatusCode::NoCredentials,
+            None,
+        )));
+        dev.add_upcoming_ctap_response(vec![new_assertion_response(&rp, Some(&allow_list[2]))]);
+        let res = silently_discover_credentials(&mut dev, &allow_list, &rp, &client_data_hash);
+        assert_eq!(res, vec![allow_list[2].clone()]);
+    }
+
+    #[test]
+    fn test_preflight_ctap2_multiple_replies() {
+        let mut dev = Device::new_skipping_serialization("preflight").unwrap();
+        make_device_with_pin(&mut dev);
+        let rp = new_relying_party("preflight test");
+        let client_data_hash = ClientDataHash(Sha256::digest("").into());
+        let allow_list = vec![
+            new_credential(4, 4),
+            new_credential(3, 4),
+            new_credential(2, 4),
+            new_credential(1, 4),
+        ];
+        let mut info = dev.get_authenticator_info().unwrap().clone();
+        info.max_credential_count_in_list = Some(5);
+        dev.set_authenticator_info(info);
+        // Our test device now says that it supports 5 allow_list-entries,
+        // so we can send all of them in one request
+        dev.add_upcoming_ctap2_request(&new_silent_assert(&rp, &allow_list));
+        dev.add_upcoming_ctap_response(vec![
+            new_assertion_response(&rp, Some(&allow_list[1])),
+            new_assertion_response(&rp, Some(&allow_list[2])),
+            new_assertion_response(&rp, Some(&allow_list[3])),
+        ]);
+        let res = silently_discover_credentials(&mut dev, &allow_list, &rp, &client_data_hash);
+        assert_eq!(res, allow_list[1..].to_vec());
+    }
+
+    #[test]
+    fn test_preflight_ctap2_multiple_replies_some_invalid() {
+        let mut dev = Device::new_skipping_serialization("preflight").unwrap();
+        make_device_with_pin(&mut dev);
+        let rp = new_relying_party("preflight test");
+        let client_data_hash = ClientDataHash(Sha256::digest("").into());
+        let allow_list = vec![
+            new_credential(4, 4),
+            new_credential(3, 4),
+            new_credential(2, 4),
+            new_credential(1, 4),
+        ];
+        let mut info = dev.get_authenticator_info().unwrap().clone();
+        info.max_credential_count_in_list = Some(5);
+        dev.set_authenticator_info(info);
+        // Our test device now says that it supports 5 allow_list-entries,
+        // so we can send all of them in one request
+        dev.add_upcoming_ctap2_request(&new_silent_assert(&rp, &allow_list));
+        dev.add_upcoming_ctap_response(vec![
+            new_assertion_response(&rp, Some(&allow_list[1])),
+            new_assertion_response(&rp, None), // This will be ignored
+            new_assertion_response(&rp, Some(&allow_list[2])),
+            new_assertion_response(&rp, None), // This will be ignored
+        ]);
+        let res = silently_discover_credentials(&mut dev, &allow_list, &rp, &client_data_hash);
+        assert_eq!(res, allow_list[1..=2].to_vec());
+    }
+
+    #[test]
+    fn test_preflight_ctap2_too_long_entries() {
+        let mut dev = Device::new_skipping_serialization("preflight").unwrap();
+        make_device_with_pin(&mut dev);
+        let rp = new_relying_party("preflight test");
+        let client_data_hash = ClientDataHash(Sha256::digest("").into());
+        let allow_list = vec![
+            new_credential(4, 50), // too long
+            new_credential(3, 4),
+            new_credential(2, 50), // too long
+            new_credential(1, 4),
+        ];
+        let mut info = dev.get_authenticator_info().unwrap().clone();
+        info.max_credential_count_in_list = Some(5);
+        info.max_credential_id_length = Some(20);
+        dev.set_authenticator_info(info);
+        // Our test device now says that it supports 5 allow_list-entries,
+        // so we can send all of them in one request, except for those
+        // that got pre-filtered, as they were too long.
+        dev.add_upcoming_ctap2_request(&new_silent_assert(
+            &rp,
+            &[allow_list[1].clone(), allow_list[3].clone()],
+        ));
+        dev.add_upcoming_ctap_response(vec![new_assertion_response(&rp, Some(&allow_list[1]))]);
+        let res = silently_discover_credentials(&mut dev, &allow_list, &rp, &client_data_hash);
+        assert_eq!(res, vec![allow_list[1].clone()]);
+    }
 }

--- a/src/transport/device_selector.rs
+++ b/src/transport/device_selector.rs
@@ -188,7 +188,7 @@ pub mod tests {
         u2ftypes::U2FDeviceInfo,
     };
 
-    fn gen_info(id: String) -> U2FDeviceInfo {
+    pub(crate) fn gen_info(id: String) -> U2FDeviceInfo {
         U2FDeviceInfo {
             vendor_name: String::from("ExampleVendor").into_bytes(),
             device_name: id.into_bytes(),
@@ -200,13 +200,16 @@ pub mod tests {
         }
     }
 
-    fn make_device_simple_u2f(dev: &mut Device) {
+    pub(crate) fn make_device_simple_u2f(dev: &mut Device) {
         dev.set_device_info(gen_info(dev.id()));
+        dev.set_cid([1, 2, 3, 4]); // Need to set something other than broadcast
+        dev.downgrade_to_ctap1();
         dev.create_channel();
     }
 
-    fn make_device_with_pin(dev: &mut Device) {
+    pub(crate) fn make_device_with_pin(dev: &mut Device) {
         dev.set_device_info(gen_info(dev.id()));
+        dev.set_cid([1, 2, 3, 4]); // Need to set something other than broadcast
         dev.create_channel();
         let info = AuthenticatorInfo {
             options: AuthenticatorOptions {

--- a/src/transport/mock/device.rs
+++ b/src/transport/mock/device.rs
@@ -4,9 +4,13 @@
 use crate::consts::{Capability, HIDCmd, CID_BROADCAST};
 use crate::crypto::SharedSecret;
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
+use crate::ctap2::commands::{CtapResponse, RequestCtap1, RequestCtap2};
 use crate::transport::device_selector::DeviceCommand;
+use crate::transport::TestDevice;
 use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol, HIDError};
 use crate::u2ftypes::{U2FDeviceInfo, U2FHIDInitResp};
+use std::any::Any;
+use std::collections::VecDeque;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Read, Write};
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -25,6 +29,9 @@ pub struct Device {
     pub sender: Option<Sender<DeviceCommand>>,
     pub receiver: Option<Receiver<DeviceCommand>>,
     pub protocol: FidoProtocol,
+    skip_serialization: bool,
+    pub upcoming_requests: VecDeque<Vec<u8>>,
+    pub upcoming_responses: VecDeque<Result<Box<dyn Any>, HIDError>>,
 }
 
 impl Device {
@@ -44,10 +51,47 @@ impl Device {
         self.reads.push(read);
     }
 
+    pub fn add_upcoming_ctap2_request(&mut self, msg: &impl RequestCtap2) {
+        self.upcoming_requests
+            .push_back(msg.wire_format().expect("Failed to serialize CTAP request"));
+    }
+
+    pub fn add_upcoming_ctap1_request(&mut self, msg: &impl RequestCtap1) {
+        let (upcoming, _) = msg
+            .ctap1_format()
+            .expect("Failed to serialize CTAP request");
+        self.upcoming_requests.push_back(upcoming);
+    }
+
+    pub fn add_upcoming_ctap_response(&mut self, msg: impl CtapResponse) {
+        self.upcoming_responses.push_back(Ok(Box::new(msg)));
+    }
+
+    pub fn add_upcoming_ctap_error(&mut self, msg: HIDError) {
+        self.upcoming_responses.push_back(Err(msg));
+    }
+
     pub fn create_channel(&mut self) {
         let (tx, rx) = channel();
         self.sender = Some(tx);
         self.receiver = Some(rx);
+    }
+
+    pub fn new_skipping_serialization(id: &str) -> Result<Self, (HIDError, String)> {
+        Ok(Device {
+            id: id.to_string(),
+            cid: CID_BROADCAST,
+            reads: vec![],
+            writes: vec![],
+            dev_info: None,
+            authenticator_info: None,
+            sender: None,
+            receiver: None,
+            protocol: FidoProtocol::CTAP2,
+            skip_serialization: true,
+            upcoming_requests: VecDeque::new(),
+            upcoming_responses: VecDeque::new(),
+        })
     }
 }
 
@@ -124,6 +168,9 @@ impl HIDDevice for Device {
             sender: None,
             receiver: None,
             protocol: FidoProtocol::CTAP2,
+            skip_serialization: false,
+            upcoming_requests: VecDeque::new(),
+            upcoming_responses: VecDeque::new(),
         })
     }
 
@@ -187,6 +234,52 @@ impl HIDDevice for Device {
         self.set_device_info(info);
 
         Ok(())
+    }
+}
+
+impl TestDevice for Device {
+    fn skip_serialization(&self) -> bool {
+        self.skip_serialization
+    }
+
+    fn send_ctap1_unserialized<Req: RequestCtap1>(
+        &mut self,
+        msg: &Req,
+    ) -> Result<Req::Output, HIDError> {
+        let expected = self
+            .upcoming_requests
+            .pop_front()
+            .expect("No expected CTAP1 command left");
+        let (incoming, _) = msg.ctap1_format().expect("Can't serialize CTAP1 request");
+        assert_eq!(expected, incoming);
+        let response = self
+            .upcoming_responses
+            .pop_front()
+            .expect("No response given!");
+        response.map(|x| {
+            *x.downcast()
+                .expect("Failed to downcast given CTAP response")
+        })
+    }
+
+    fn send_ctap2_unserialized<Req: RequestCtap2>(
+        &mut self,
+        msg: &Req,
+    ) -> Result<Req::Output, HIDError> {
+        let expected = self
+            .upcoming_requests
+            .pop_front()
+            .expect("No expected CTAP2 command left");
+        let incoming = msg.wire_format().expect("Can't serialize CTAP2 request");
+        assert_eq!(expected, incoming);
+        let response = self
+            .upcoming_responses
+            .pop_front()
+            .expect("No response given!");
+        response.map(|x| {
+            *x.downcast()
+                .expect("Failed to downcast given CTAP response")
+        })
     }
 }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -112,6 +112,21 @@ pub trait FidoDeviceIO {
     ) -> Result<Req::Output, HIDError>;
 }
 
+pub trait TestDevice {
+    #[cfg(test)]
+    fn skip_serialization(&self) -> bool;
+    #[cfg(test)]
+    fn send_ctap1_unserialized<Req: RequestCtap1>(
+        &mut self,
+        msg: &Req,
+    ) -> Result<Req::Output, HIDError>;
+    #[cfg(test)]
+    fn send_ctap2_unserialized<Req: RequestCtap2>(
+        &mut self,
+        msg: &Req,
+    ) -> Result<Req::Output, HIDError>;
+}
+
 pub trait FidoDevice: FidoDeviceIO
 where
     Self: Sized,


### PR DESCRIPTION
Fix bug in preflighting, where CTAP2.0 devices can omit the credential data if the allow_list is of length one. Without this fix, those answer get ignored and the device discarded as being not useable.

Adding a bunch of prefligh-tests. For this, I had to extend the mock device to be able to skip the low-level byte-by-byte comparison of incoming and outgoing data, and instead use CTAP requests and responses directly, for higher-level business-logic testing. 
Now, we can add what requests we expect, and what responses the mock device should give.
For this, CTAP-responses have to be marked with their own marker trait, so that we can collect all different responses as `dyn std::any::Any` in a single `Vec`. For that, responses have to be marked `'static` (required by `Any`), but since all of our Responses are `'static`, this is currently not a problem.

And a new TestDevice-trait has been added, which is a no-op implementation in release-mode, but gives us the ability to skip the low-level serialization of requests. Only the mock-device actually implements something.
It is currently decided upon creation of the device (using the two `new*()`-functions), if it should skip the serialization or not.