### PR TITLE
fixes #74: replaces `read_uint_le` with utility function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@ fuzz/corpus/
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock
 
+# Editor files
+.vscode
+
 .DS_Store

--- a/src/transport/hidproto.rs
+++ b/src/transport/hidproto.rs
@@ -86,7 +86,6 @@ impl ReportDescriptorIterator {
         assert!(data.len() <= mem::size_of::<u32>());
 
         // Convert data bytes to a uint.
-        // let data = read_uint_le(data);
         let data = data.read_u8::<LittleEndian>().unwrap();
         match tag_type {
             HID_ITEM_TAGTYPE_USAGE_PAGE => Some(Data::UsagePage { data }),
@@ -153,14 +152,6 @@ fn get_hid_short_item<'a>(buf: &'a [u8]) -> Option<(u8, usize, &'a [u8])> {
         1, /* key length */
         &buf[1..=len],
     ))
-}
-
-fn read_uint_le(buf: &[u8]) -> u32 {
-    assert!(buf.len() <= 4);
-    // Parse the number in little endian byte order.
-    buf.iter()
-        .rev()
-        .fold(0, |num, b| (num << 8) | (u32::from(*b)))
 }
 
 pub fn has_fido_usage(desc: ReportDescriptor) -> bool {

--- a/src/transport/hidproto.rs
+++ b/src/transport/hidproto.rs
@@ -13,6 +13,8 @@
 use std::io;
 use std::mem;
 
+use byteorder::{LittleEndian, ReadBytesExt};
+
 use crate::consts::{FIDO_USAGE_PAGE, FIDO_USAGE_U2FHID};
 #[cfg(target_os = "linux")]
 use crate::consts::{INIT_HEADER_SIZE, MAX_HID_RPT_SIZE};
@@ -84,7 +86,8 @@ impl ReportDescriptorIterator {
         assert!(data.len() <= mem::size_of::<u32>());
 
         // Convert data bytes to a uint.
-        let data = read_uint_le(data);
+        // let data = read_uint_le(data);
+        let data = data.read_u8::<LittleEndian>().unwrap();
         match tag_type {
             HID_ITEM_TAGTYPE_USAGE_PAGE => Some(Data::UsagePage { data }),
             HID_ITEM_TAGTYPE_USAGE => Some(Data::Usage { data }),


### PR DESCRIPTION
resolves #74 

Hello! Learning rust, so please excuse me for being misinformed in any way 😄. Any comments or feedback on this would be greatly appreciated!

I had trouble building this off of the default `ctap2-2021` branch (did 
```sh
$ cargo build --example main
# also tried
$ cargo test
``` as the README states, but neither worked), so I tried running the same fix off of `main` where there's similar code. I got a completed run of `cargo test`, but I was not able to get a reproducible failure when just commenting out the old function. I feel I may have missed something with my testing, so, again, any sort of help would be awesome.