### PR TITLE
Add tests to check that all CBOR requests are in canonicalized form

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -39,7 +39,7 @@ mod der;
 
 pub use backend::ecdsa_p256_sha256_sign_raw;
 
-pub struct PinUvAuthProtocol(Box<dyn PinProtocolImpl + Send + Sync>);
+pub struct PinUvAuthProtocol(pub(crate) Box<dyn PinProtocolImpl + Send + Sync>);
 impl PinUvAuthProtocol {
     pub fn id(&self) -> u64 {
         self.0.protocol_id()
@@ -53,7 +53,7 @@ impl PinUvAuthProtocol {
 /// PinProtocolImpl. So we stash a copy of the calling PinUvAuthProtocol in the output SharedSecret.
 /// We need a trick here to tell the compiler that every PinProtocolImpl we define will implement
 /// Clone.
-trait ClonablePinProtocolImpl {
+pub(crate) trait ClonablePinProtocolImpl {
     fn clone_box(&self) -> Box<dyn PinProtocolImpl + Send + Sync>;
 }
 
@@ -73,7 +73,7 @@ impl Clone for PinUvAuthProtocol {
 }
 
 /// CTAP 2.1, Section 6.5.4. PIN/UV Auth Protocol Abstract Definition
-trait PinProtocolImpl: ClonablePinProtocolImpl {
+pub(crate) trait PinProtocolImpl: ClonablePinProtocolImpl {
     fn protocol_id(&self) -> u64;
     fn initialize(&self);
     fn encrypt(&self, key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, CryptoError>;
@@ -364,10 +364,10 @@ impl PinUvAuthToken {
 
 #[derive(Clone, Debug)]
 pub struct PinUvAuthParam {
-    pin_auth: Vec<u8>,
+    pub(crate) pin_auth: Vec<u8>,
     pub pin_protocol: PinUvAuthProtocol,
     #[allow(dead_code)] // Not yet used
-    permissions: PinUvAuthTokenPermission,
+    pub(crate) permissions: PinUvAuthTokenPermission,
 }
 
 impl PinUvAuthParam {

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -618,7 +618,7 @@ pub mod test {
     use crate::ctap2::commands::get_info::{
         AuthenticatorInfo, AuthenticatorOptions, AuthenticatorVersion,
     };
-    use crate::ctap2::commands::RequestCtap1;
+    use crate::ctap2::commands::{assert_canonical_cbor_encoding, RequestCtap1};
     use crate::ctap2::preflight::{
         do_credential_list_filtering_ctap1, do_credential_list_filtering_ctap2,
     };
@@ -660,6 +660,7 @@ pub mod test {
             },
             Default::default(),
         );
+        assert_canonical_cbor_encoding(&assertion);
         let mut device = Device::new("commands/get_assertion").unwrap();
         assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
         let mut cid = [0u8; 4];
@@ -859,6 +860,7 @@ pub mod test {
             },
             Default::default(),
         );
+        assert_canonical_cbor_encoding(&assertion);
         let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
                                                                          // channel id
         device.downgrade_to_ctap1();
@@ -948,6 +950,7 @@ pub mod test {
             },
             Default::default(),
         );
+        assert_canonical_cbor_encoding(&assertion);
 
         let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
                                                                          // channel id
@@ -1128,6 +1131,7 @@ pub mod test {
             },
             Default::default(),
         );
+        assert_canonical_cbor_encoding(&assertion);
         let mut device = Device::new("commands/get_assertion").unwrap();
         assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
         let mut cid = [0u8; 4];

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -605,7 +605,7 @@ pub mod test {
         AuthenticatorDataFlags, Signature,
     };
     use crate::ctap2::client_data::{Challenge, CollectedClientData, TokenBinding, WebauthnType};
-    use crate::ctap2::commands::{RequestCtap1, RequestCtap2};
+    use crate::ctap2::commands::{assert_canonical_cbor_encoding, RequestCtap1, RequestCtap2};
     use crate::ctap2::server::RpIdHash;
     use crate::ctap2::server::{
         AuthenticatorAttachment, PublicKeyCredentialParameters, PublicKeyCredentialUserEntity,
@@ -654,6 +654,7 @@ pub mod test {
             },
             Default::default(),
         );
+        assert_canonical_cbor_encoding(&req);
 
         let mut device = Device::new("commands/make_credentials").unwrap(); // not really used (all functions ignore it)
         assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
@@ -709,6 +710,7 @@ pub mod test {
             },
             Default::default(),
         );
+        assert_canonical_cbor_encoding(&req);
 
         let (req_serialized, _) = req
             .ctap1_format()


### PR DESCRIPTION
This adds just tests (and changes some visibilities where necessary) – I found no requests that weren't already meeting the canonicalization requirements, so the behavior of the lib itself stays unchanged.

Closes #225.