### PR TITLE
Only create shared secret, when hmac is requested for CTAP2.0 tokens

### DIFF
--- a/src/ctap2/commands/authenticator_config.rs
+++ b/src/ctap2/commands/authenticator_config.rs
@@ -188,6 +188,10 @@ impl PinUvAuthCommand for AuthenticatorConfig {
     fn get_rp_id(&self) -> Option<&String> {
         None
     }
+
+    fn hmac_requested(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/ctap2/commands/bio_enrollment.rs
+++ b/src/ctap2/commands/bio_enrollment.rs
@@ -224,6 +224,10 @@ impl PinUvAuthCommand for BioEnrollment {
     fn get_pin_uv_auth_param(&self) -> Option<&PinUvAuthParam> {
         self.pin_uv_auth_param.as_ref()
     }
+
+    fn hmac_requested(&self) -> bool {
+        false
+    }
 }
 
 impl RequestCtap2 for BioEnrollment {

--- a/src/ctap2/commands/credential_management.rs
+++ b/src/ctap2/commands/credential_management.rs
@@ -421,6 +421,10 @@ impl PinUvAuthCommand for CredentialManagement {
     fn get_pin_uv_auth_param(&self) -> Option<&PinUvAuthParam> {
         self.pin_uv_auth_param.as_ref()
     }
+
+    fn hmac_requested(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -477,6 +477,10 @@ impl PinUvAuthCommand for GetAssertion {
     fn get_pin_uv_auth_param(&self) -> Option<&PinUvAuthParam> {
         self.pin_uv_auth_param.as_ref()
     }
+
+    fn hmac_requested(&self) -> bool {
+        self.extensions.hmac_secret.is_some()
+    }
 }
 
 impl Serialize for GetAssertion {

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -468,6 +468,14 @@ impl PinUvAuthCommand for MakeCredentials {
     fn get_pin_uv_auth_param(&self) -> Option<&PinUvAuthParam> {
         self.pin_uv_auth_param.as_ref()
     }
+
+    fn hmac_requested(&self) -> bool {
+        !(self.extensions.hmac_secret.is_none()
+            || matches!(
+                self.extensions.hmac_secret,
+                Some(HmacCreateSecretOrPrf::HmacCreateSecret(false))
+            ))
+    }
 }
 
 impl Serialize for MakeCredentials {

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -143,6 +143,7 @@ pub(crate) trait PinUvAuthCommand: RequestCtap2 {
     fn get_pin_uv_auth_param(&self) -> Option<&PinUvAuthParam>;
     fn set_uv_option(&mut self, uv: Option<bool>);
     fn get_rp_id(&self) -> Option<&String>;
+    fn hmac_requested(&self) -> bool;
     fn can_skip_user_verification(
         &mut self,
         info: &AuthenticatorInfo,

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -288,9 +288,9 @@ fn get_pin_uv_auth_param<Dev: FidoDevice, T: PinUvAuthCommand + RequestCtap2>(
             // If the device supports internal user-verification (e.g. fingerprints),
             // skip PIN-stuff
 
-            // We may need the shared secret for HMAC-extension, so we
+            // We need the shared secret for HMAC-extension, if it was requested, so we
             // have to establish one
-            if info.supports_hmac_secret() {
+            if cmd.hmac_requested() && info.supports_hmac_secret() {
                 let _shared_secret = dev.establish_shared_secret(alive)?;
             }
             // CTAP 2.1, Section 6.1.1, Step 1.1.2.1.2.


### PR DESCRIPTION
I don't have a fitting token to test this, sadly. 