### PR TITLE
Tolerate unknown AuthenticatorVersion values while deserializing

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -40,9 +40,18 @@ pub use backend::ecdsa_p256_sha256_sign_raw;
 
 pub struct PinUvAuthProtocol(Box<dyn PinProtocolImpl + Send + Sync>);
 impl PinUvAuthProtocol {
+    pub fn from_id(id: u64) -> Option<Self> {
+        match id {
+            1 => Some(Self(Box::new(PinUvAuth1 {}))),
+            2 => Some(Self(Box::new(PinUvAuth2 {}))),
+            _ => None,
+        }
+    }
+
     pub fn id(&self) -> u64 {
         self.0.protocol_id()
     }
+
     pub fn encapsulate(&self, peer_cose_key: &COSEKey) -> Result<SharedSecret, CryptoError> {
         self.0.encapsulate(peer_cose_key)
     }
@@ -141,13 +150,11 @@ impl TryFrom<&AuthenticatorInfo> for PinUvAuthProtocol {
         // has no preference, it SHOULD select the one listed first in
         // pinUvAuthProtocols."
         if let Some(pin_protocols) = &info.pin_protocols {
-            for proto_id in pin_protocols.iter() {
-                match proto_id {
-                    1 => return Ok(PinUvAuthProtocol(Box::new(PinUvAuth1 {}))),
-                    2 => return Ok(PinUvAuthProtocol(Box::new(PinUvAuth2 {}))),
-                    _ => continue,
-                }
-            }
+            pin_protocols
+                .iter()
+                .copied()
+                .find_map(PinUvAuthProtocol::from_id)
+                .ok_or(CommandError::UnsupportedPinProtocol)
         } else {
             match info.max_supported_version() {
                 crate::ctap2::commands::get_info::AuthenticatorVersion::U2F_V2 => {
@@ -162,7 +169,6 @@ impl TryFrom<&AuthenticatorInfo> for PinUvAuthProtocol {
                 }
             }
         }
-        Err(CommandError::UnsupportedPinProtocol)
     }
 }
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -158,14 +158,14 @@ impl TryFrom<&AuthenticatorInfo> for PinUvAuthProtocol {
         } else {
             match info.max_supported_version() {
                 crate::ctap2::commands::get_info::AuthenticatorVersion::U2F_V2 => {
-                    return Err(CommandError::UnsupportedPinProtocol)
+                    Err(CommandError::UnsupportedPinProtocol)
                 }
                 crate::ctap2::commands::get_info::AuthenticatorVersion::FIDO_2_0 => {
-                    return Ok(PinUvAuthProtocol(Box::new(PinUvAuth1 {})))
+                    Ok(PinUvAuthProtocol(Box::new(PinUvAuth1 {})))
                 }
                 crate::ctap2::commands::get_info::AuthenticatorVersion::FIDO_2_1_PRE
                 | crate::ctap2::commands::get_info::AuthenticatorVersion::FIDO_2_1 => {
-                    return Ok(PinUvAuthProtocol(Box::new(PinUvAuth2 {})))
+                    Ok(PinUvAuthProtocol(Box::new(PinUvAuth2 {})))
                 }
             }
         }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -157,7 +157,9 @@ impl TryFrom<&AuthenticatorInfo> for PinUvAuthProtocol {
                 .ok_or(CommandError::UnsupportedPinProtocol)
         } else {
             match info.max_supported_version() {
-                AuthenticatorVersion::U2F_V2 => Err(CommandError::UnsupportedPinProtocol),
+                AuthenticatorVersion::U2F_V2 | AuthenticatorVersion::Unknown => {
+                    Err(CommandError::UnsupportedPinProtocol)
+                }
                 AuthenticatorVersion::FIDO_2_0 => Ok(PinUvAuthProtocol(Box::new(PinUvAuth1 {}))),
                 AuthenticatorVersion::FIDO_2_1_PRE | AuthenticatorVersion::FIDO_2_1 => {
                     Ok(PinUvAuthProtocol(Box::new(PinUvAuth2 {})))

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::ctap2::commands::client_pin::PinUvAuthTokenPermission;
-use crate::ctap2::commands::get_info::AuthenticatorInfo;
+use crate::ctap2::commands::get_info::{AuthenticatorInfo, AuthenticatorVersion};
 use crate::errors::AuthenticatorError;
 use crate::{ctap2::commands::CommandError, transport::errors::HIDError};
 use serde::{
@@ -157,14 +157,9 @@ impl TryFrom<&AuthenticatorInfo> for PinUvAuthProtocol {
                 .ok_or(CommandError::UnsupportedPinProtocol)
         } else {
             match info.max_supported_version() {
-                crate::ctap2::commands::get_info::AuthenticatorVersion::U2F_V2 => {
-                    Err(CommandError::UnsupportedPinProtocol)
-                }
-                crate::ctap2::commands::get_info::AuthenticatorVersion::FIDO_2_0 => {
-                    Ok(PinUvAuthProtocol(Box::new(PinUvAuth1 {})))
-                }
-                crate::ctap2::commands::get_info::AuthenticatorVersion::FIDO_2_1_PRE
-                | crate::ctap2::commands::get_info::AuthenticatorVersion::FIDO_2_1 => {
+                AuthenticatorVersion::U2F_V2 => Err(CommandError::UnsupportedPinProtocol),
+                AuthenticatorVersion::FIDO_2_0 => Ok(PinUvAuthProtocol(Box::new(PinUvAuth1 {}))),
+                AuthenticatorVersion::FIDO_2_1_PRE | AuthenticatorVersion::FIDO_2_1 => {
                     Ok(PinUvAuthProtocol(Box::new(PinUvAuth2 {})))
                 }
             }


### PR DESCRIPTION
I recently got a prototype FIDO_2_2 authenticator and noticed that WebAuthn operations with it fails when `userVerification: "required"`, or when `residentKey: "required"`. I traced the root cause to the deserialization of `AuthenticatorVersion`, which is intolerant of unknown values such as `"FIDO_2_2"`. This causes Firefox to downgrade to the CTAP1 protocol for any authenticator whose getInfo contains `"FIDO_2_2"` (or any other unknown value, such as future versions), preventing use of any CTAP2-exclusive features with those authenticators.

# Reproducing the issue

1. Launch Firefox 139.0 and open https://demo.yubico.com/webauthn-developers
2. In “Authenticator selection”, uncheck “excludeCredentials” and set “userVerification” to “discouraged”. Click “CREATE” at the bottom and create a credential using a FIDO_2_2 authenticator. Observe that the credential registration succeeds.
3. In “Authenticator selection”,  change “userVerification to “required”. Again click “CREATE” at the bottom and create a credential using a FIDO_2_2 authenticator. Observe that the credential registration now fails.

# Fixing the issue

This adds an `AuthenticatorVersion::Unknown` variant with [`#[serde(other)]`](https://serde.rs/variant-attrs.html#other), causing unknown values to deserialize to that variant instead of being rejected. This is enough to prevent Firefox from downgrading FIDO_2_2 devices to CTAP1, so they can successfully use UV and other CTAP2-exclusive features.

This PR does _not_ add a `FIDO_2_2` variant since that would not actually add support for any features introduced in FIDO_2_2.