### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,6 @@ env_logger = "^0.6"
 getopts = "^0.2"
 assert_matches = "1.2"
 rpassword = "5.0"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authenticator"
-version = "0.4.1"
+version = "0.5.0"
 authors = [ "Dana Keeler <dkeeler@mozilla.com>", "J.C. Jones <jc@mozilla.com>", "John Schanck <jschanck@mozilla.com>", "Kyle Machulis <kyle@nonpolynomial.com>", "Martin Sirringhaus <martin.sirringhaus@suse.com", "Tim Taubert <ttaubert@mozilla.com>" ]
 keywords = ["ctap2", "u2f", "fido", "webauthn"]
 categories = ["cryptography", "hardware-support", "os"]

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -88,7 +88,6 @@ impl Clone for PinUvAuthProtocol {
 /// CTAP 2.1, Section 6.5.4. PIN/UV Auth Protocol Abstract Definition
 trait PinProtocolImpl: ClonablePinProtocolImpl {
     fn protocol_id(&self) -> u64;
-    fn initialize(&self);
     fn encrypt(&self, key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, CryptoError>;
     fn decrypt(&self, key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, CryptoError>;
     fn authenticate(&self, key: &[u8], message: &[u8]) -> Result<Vec<u8>, CryptoError>;
@@ -189,8 +188,6 @@ impl PinProtocolImpl for PinUvAuth1 {
         1
     }
 
-    fn initialize(&self) {}
-
     fn encrypt(&self, key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, CryptoError> {
         // [CTAP 2.1]
         // encrypt(key, demPlaintext) → ciphertext
@@ -233,8 +230,6 @@ impl PinProtocolImpl for PinUvAuth2 {
     fn protocol_id(&self) -> u64 {
         2
     }
-
-    fn initialize(&self) {}
 
     fn encrypt(&self, key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, CryptoError> {
         // [CTAP 2.1]

--- a/src/transport/device_selector.rs
+++ b/src/transport/device_selector.rs
@@ -10,8 +10,6 @@ use std::time::Duration;
 pub type DeviceID = <Device as HIDDevice>::Id;
 pub type DeviceBuildParameters = <Device as HIDDevice>::BuildParameters;
 
-trait DeviceSelectorEventMarker {}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlinkResult {
     DeviceSelected,

--- a/src/transport/hidproto.rs
+++ b/src/transport/hidproto.rs
@@ -4,10 +4,7 @@
 
 // Shared code for platforms that use raw HID access (Linux, FreeBSD, etc.)
 
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(clippy::cast_lossless, clippy::needless_lifetimes)
-)]
+#![allow(clippy::cast_lossless, clippy::needless_lifetimes)]
 
 #[cfg(target_os = "linux")]
 use std::io;

--- a/src/transport/linux/hidraw.rs
+++ b/src/transport/linux/hidraw.rs
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::cast_lossless))]
+#![allow(clippy::cast_lossless)]
 
 extern crate libc;
 


### PR DESCRIPTION
Bump version to 0.5.0 and fix a few build warnings/errors that turned up when I tried vendoring this into Firefox.

```
error: unexpected `cfg` condition name: `fuzzing`
error: unexpected `cfg` condition value: `cargo-clippy`
error: trait `DeviceSelectorEventMarker` is never used
error: method `initialize` is never used
```