### PR TITLE
Bump core-foundation dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libudev = "^0.2"
 devd-rs = "0.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.9"
+core-foundation = "0.10"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 memoffset = "0.8"


### PR DESCRIPTION
This PR just makes a small dependency bump. While AFAICT `authenticator` doesn't use the `CFData` bindings, updating brings in the changes from https://github.com/servo/core-foundation-rs/pull/688 and prevents the UB problem from being a real issue in the future.