### PR TITLE
Use serde_cbor_2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ runloop = "0.1.0"
 bitflags = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
-serde_cbor = "0.11"
+serde_cbor = { package = "serde_cbor_2", version = "0.13" }
 serde_json = "1.0"
 bytes = { version = "0.5", optional = true, features = ["serde"] }
 base64 = "^0.21"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Current rust version for mozilla-central
 # https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html
-channel = "1.73.0"
+channel = "1.82.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/src/crypto/rustcrypto.rs
+++ b/src/crypto/rustcrypto.rs
@@ -11,14 +11,8 @@ pub type Result<T> = std::result::Result<T, CryptoError>;
 fn cose_key_to_public(peer: &super::COSEEC2Key) -> Result<p256::PublicKey> {
     // SEC 1 encoded uncompressed point
     let peer = p256::EncodedPoint::from_affine_coordinates(
-        peer.x
-            .as_slice()
-            .try_into()
-            .map_err(|_| CryptoError::MalformedInput)?,
-        peer.y
-            .as_slice()
-            .try_into()
-            .map_err(|_| CryptoError::MalformedInput)?,
+        peer.x.as_slice().into(),
+        peer.y.as_slice().into(),
         false,
     );
     p256::PublicKey::from_encoded_point(&peer)
@@ -51,11 +45,7 @@ pub fn encrypt_aes_256_cbc_no_pad(key: &[u8], iv: Option<&[u8]>, data: &[u8]) ->
         Err(_) => return Err(CryptoError::LibraryFailure),
     };
 
-    let iv = iv.unwrap_or(&[0u8; AES_BLOCK_SIZE]);
-    let iv = match iv.try_into() {
-        Ok(iv) => iv,
-        Err(_) => return Err(CryptoError::LibraryFailure),
-    };
+    let iv = iv.unwrap_or(&[0u8; AES_BLOCK_SIZE]).into();
 
     // Validate that the data is an exact multiple of the block size since we have no
     // padding available.
@@ -90,11 +80,7 @@ pub fn decrypt_aes_256_cbc_no_pad(key: &[u8], iv: Option<&[u8]>, data: &[u8]) ->
         Err(_) => return Err(CryptoError::LibraryFailure),
     };
 
-    let iv = iv.unwrap_or(&[0u8; AES_BLOCK_SIZE]);
-    let iv = match iv.try_into() {
-        Ok(iv) => iv,
-        Err(_) => return Err(CryptoError::LibraryFailure),
-    };
+    let iv = iv.unwrap_or(&[0u8; AES_BLOCK_SIZE]).into();
 
     // See comments in `encrypt_aes_256_cbc_no_pad` for rationale.
     let blocks = data.chunks_exact(AES_BLOCK_SIZE);

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -62,11 +62,7 @@ impl GetAssertionOptions {
 
 impl UserVerification for GetAssertionOptions {
     fn ask_user_verification(&self) -> bool {
-        if let Some(e) = self.user_verification {
-            e
-        } else {
-            false
-        }
+        self.user_verification.unwrap_or(false)
     }
 }
 

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -261,11 +261,7 @@ pub(crate) trait UserVerification {
 
 impl UserVerification for MakeCredentialsOptions {
     fn ask_user_verification(&self) -> bool {
-        if let Some(e) = self.user_verification {
-            e
-        } else {
-            false
-        }
+        self.user_verification.unwrap_or(false)
     }
 }
 

--- a/src/transport/hidproto.rs
+++ b/src/transport/hidproto.rs
@@ -47,6 +47,7 @@ pub enum Data {
     Usage { data: u32 },
     Input,
     Output,
+    #[allow(dead_code)] // we only read this on linux
     ReportCount { data: u32 },
 }
 

--- a/src/transport/linux/monitor.rs
+++ b/src/transport/linux/monitor.rs
@@ -17,7 +17,7 @@ const UDEV_SUBSYSTEM: &str = "hidraw";
 const POLLIN: c_short = 0x0001;
 const POLL_TIMEOUT: c_int = 100;
 
-fn poll(fds: &mut Vec<::libc::pollfd>) -> io::Result<()> {
+fn poll(fds: &mut [::libc::pollfd]) -> io::Result<()> {
     let nfds = fds.len() as c_ulong;
 
     let rv = unsafe { ::libc::poll((fds[..]).as_mut_ptr(), nfds, POLL_TIMEOUT) };

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,16 +18,19 @@ macro_rules! try_or {
     };
 }
 
+#[cfg(all(not(test), any(target_os = "linux", target_os = "freebsd", target_os = "openbsd")))]
 pub trait Signed {
     fn is_negative(&self) -> bool;
 }
 
+#[cfg(all(not(test), any(target_os = "linux", target_os = "freebsd", target_os = "openbsd")))]
 impl Signed for i32 {
     fn is_negative(&self) -> bool {
         *self < 0
     }
 }
 
+#[cfg(all(not(test), any(target_os = "linux", target_os = "freebsd", target_os = "openbsd")))]
 impl Signed for usize {
     fn is_negative(&self) -> bool {
         (*self as isize) < 0


### PR DESCRIPTION
Firefox vendoring scripts have started complaining ([Bug 1998418](https://bugzilla.mozilla.org/show_bug.cgi?id=1998418)) about the fact that the serde_cbor repo is archived. There's a maintained serde_cbor_2 fork [here](https://github.com/kanidm/cbor).

Resolves #327. 