### PR TITLE
Linux: add a 2 second read timeout for USB HID

### DIFF
--- a/src/transport/linux/device.rs
+++ b/src/transport/linux/device.rs
@@ -9,13 +9,27 @@ use crate::transport::hid::HIDDevice;
 use crate::transport::platform::{hidraw, monitor};
 use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
-use crate::util::from_unix_result;
+use crate::util::{from_unix_result, io_err};
 use std::fs::OpenOptions;
 use std::hash::{Hash, Hasher};
 use std::io;
 use std::io::{Read, Write};
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
+
+/// USB HID read timeout, in milliseconds.
+///
+/// This is needed to prevent devices (particularly virtual `uhid` bridge devices) that *don't*
+/// respond in a timely manner from [causing the browser to hang][0].
+///
+/// [CTAP 2.3 §11.2.9.1.7][1] says devices SHOULD send `CTAPHID_KEEPALIVE` every 100ms while
+/// processing a `CTAPHID_MSG` or `CTAPHID_CBOR`. This gives devices 2 seconds to send a
+/// `CTAPHID_KEEPALIVE`. [`HIDDevice::sendrecv`][] lets an application interrupt an authenticator
+/// sending `CTAPHID_KEEPALIVE` forever.
+///
+/// [0]: https://bugzilla.mozilla.org/show_bug.cgi?id=1958831
+/// [1]: https://fidoalliance.og/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#usb-hid-keepalive
+const READ_TIMEOUT: i32 = 2000;
 
 #[derive(Debug)]
 pub struct Device {
@@ -50,6 +64,18 @@ impl Hash for Device {
 
 impl Read for Device {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // Check that we can actually read from the device.
+        let mut pfd: libc::pollfd = unsafe { std::mem::zeroed() };
+        pfd.fd = self.fd.as_raw_fd();
+        pfd.events = libc::POLLIN;
+        let nfds = unsafe { libc::poll(&mut pfd, 1, READ_TIMEOUT) };
+        if nfds == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        if nfds == 0 {
+            return Err(io_err("no response from device"));
+        }
+
         let bufp = buf.as_mut_ptr() as *mut libc::c_void;
         let rv = unsafe { libc::read(self.fd.as_raw_fd(), bufp, buf.len()) };
         from_unix_result(rv as usize)

--- a/src/transport/linux/device.rs
+++ b/src/transport/linux/device.rs
@@ -65,14 +65,19 @@ impl Hash for Device {
 impl Read for Device {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         // Check that we can actually read from the device.
-        let mut pfd: libc::pollfd = unsafe { std::mem::zeroed() };
-        pfd.fd = self.fd.as_raw_fd();
-        pfd.events = libc::POLLIN;
+        let mut pfd = libc::pollfd {
+            fd: self.fd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
         let nfds = unsafe { libc::poll(&mut pfd, 1, READ_TIMEOUT) };
-        if nfds == -1 {
+        if nfds == -1 || pfd.revents & libc::POLLERR != 0 {
             return Err(io::Error::last_os_error());
         }
-        if nfds == 0 {
+        if pfd.revents & libc::POLLNVAL != 0 {
+            return Err(io::Error::from_raw_os_error(libc::EBADF));
+        }
+        if nfds == 0 || pfd.revents & libc::POLLIN == 0 {
             return Err(io_err("no response from device"));
         }
 


### PR DESCRIPTION
Adds a 2 second `read()` timeout for USB HID on Linux.

Potentially fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1958831

### Background

There are a few projects which extend Firefox/`authenticator-rs`' CTAP2 transport support by using `uhid` (and similar) to simulate a USB HID authenticator and proxying commands (eg: BTLE, PC/SC, TPM).

Unfortunately, some of these transports are slower and less reliable than USB, and simulated devices may not even [send `CTAPHID_KEEPALIVE` as frequently as suggested by the spec][0] (100 ms). Sometimes they stop responding entirely, rather than reporting an error. A misbehaving device can cause an application using this library to hang, potentially indefinitely.

I've written a tester for Linux which looks like a USB HID authenticator but never responds sends any replies (or always replies with `CTAPHID_KEEPALIVE`), which causes `authenticator_rs` and (current) Firefox to hang: https://github.com/micolous/webauthn-toys/tree/main/fido_tarpit

While `authenticator-rs` has a ~20 second timeout where the device will be "removed", the slow `read()` won't ever be interrupted, and it won't proceed to send further commands to a _working_ authenticator. In Firefox, the browser just entirely stops responding after a WebAuthn request.

### In this PR

This PR applies a 2 second timeout on all USB HID reads on Linux by `poll()`ing before each `read()` (ie: 20x recommended time). Authenticators can still respond with `CTAPHID_KEEPALIVE` before this timeout, and get extra time.

Applications can still pass a `keep_alive` parameter to impose further deadlines on _some_ requests, and interrupt unreasonably slow authenticators.

I tested this against about a dozen USB HID U2F and FIDO2 authenticators from many vendors, and they all easily meet the timeout.

### Not addressed by this PR

An authenticator can still stall indefinitely by sending `CTAPHID_KEEPALIVE` in response to `CTAPHID_INIT` (which isn't allowed by the spec) or a `CTAPHID_CBOR` `authenticatorGetInfo` request, and trigger lock-ups.

I started investigating solutions in https://github.com/micolous/authenticator-rs/tree/ctap2/1958831-ignore-unexpected-timeouts, but that will require more invasive changes across all platforms (as it would require all requests become cancellable).

Only macOS applies any timeout on `read()`. Other platforms may wish to consider similar changes, but testing these is hard :)

Another issue is that if [the hard-coded 100 second timeout](https://github.com/mozilla/authenticator-rs/blob/86caf8b8bcda16d8a36325e9e78f8da2c46084e2/src/transport/device_selector.rs#L58-L59) is reached, [`DeviceSelector` will cancel the pending operation](https://github.com/mozilla/authenticator-rs/blob/86caf8b8bcda16d8a36325e9e78f8da2c46084e2/src/transport/device_selector.rs#L68-L72), rather than continuing without unresponsive device(s). This could be changed so that devices are allowed to stay in `waiting_for_device` state after reaching a (shorter) init timeout, then treat it like a multi-device flow (requiring an extra touch), but there's no reason a spec-compliant device should need this.

### Potential breakages

This PR will potentially break _really slow_ (physical and virtual) devices. As noted above, these do not meet [the CTAP specification's recommendations][0].

Virtual devices with slow transports should attempt to send and cache an `authenticatorGetInfo` request on application start-up or user activity (wake/unlock screen), and only present a virtual device when the transport is actually usable. They must also return an error on transport-level errors or timeouts.

`authenticator-rs` will discover new devices that become present during a registration/authentication ceremony, so a virtual device doesn't have to be present at all times if it is the _only_ FIDO USB HID.

[0]: https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#usb-hid-keepalive
