### PR TITLE
Remove dependency on `memoffset` for `target_os = "windows"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,6 @@ devd-rs = "0.3"
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-memoffset = "0.8"
-
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "^0.3"
 features = [

--- a/src/transport/windows/winapi.rs
+++ b/src/transport/windows/winapi.rs
@@ -203,7 +203,7 @@ impl DeviceInterfaceDetailData {
         unsafe { (*data).cbSize = cb_size as minwindef::UINT };
 
         // Compute offset of `SP_DEVICE_INTERFACE_DETAIL_DATA_W.DevicePath`.
-        let offset = memoffset::offset_of!(setupapi::SP_DEVICE_INTERFACE_DETAIL_DATA_W, DevicePath);
+        let offset = mem::offset_of!(setupapi::SP_DEVICE_INTERFACE_DETAIL_DATA_W, DevicePath);
 
         Some(Self {
             data,


### PR DESCRIPTION
Hi, thanks for firefox!
I'm going down the list of reverse dependencies on `memoffset`.

This PR aims to remove the `memoffset` crate from your dependencies.
[`core::mem::offset_of`](https://doc.rust-lang.org/core/mem/macro.offset_of.html) was stabilised in rustc 1.77.

The `memoffset` crate 0.9.1 says that

> If you're using a rustc version greater or equal to 1.77,
> this crate's offset_of!() macro simply forwards to core::mem::offset_of!().

I consider it very unlikely (see [here](https://github.com/rust-lang/rust/issues/111839)) for any usage of the `offset_of!` macro to break but please check anyway.
I hope we can all enjoy the benefits of one less dependency :)

---

Your MSRV is unclear to me but [this](https://github.com/mozilla/authenticator-rs/pull/316#issuecomment-1800151607) implies it's currently 1.90, maybe set it in `Cargo.toml`?
If that is correct [this comment](https://github.com/mozilla/authenticator-rs/blob/86caf8b8bcda16d8a36325e9e78f8da2c46084e2/src/crypto/rustcrypto.rs#L62) can also be followed up on.