### PR TITLE
example/ctap2: allow changing `user_verification_req`, check UV bit

### DIFF
--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -5,11 +5,14 @@
 use authenticator::{
     authenticatorservice::{AuthenticatorService, RegisterArgs, SignArgs},
     crypto::COSEAlgorithm,
-    ctap2::server::{
-        AuthenticationExtensionsClientInputs, CredentialProtectionPolicy,
-        PublicKeyCredentialDescriptor, PublicKeyCredentialParameters,
-        PublicKeyCredentialUserEntity, RelyingParty, ResidentKeyRequirement, Transport,
-        UserVerificationRequirement,
+    ctap2::{
+        attestation::AuthenticatorDataFlags,
+        server::{
+            AuthenticationExtensionsClientInputs, CredentialProtectionPolicy,
+            PublicKeyCredentialDescriptor, PublicKeyCredentialParameters,
+            PublicKeyCredentialUserEntity, RelyingParty, ResidentKeyRequirement, Transport,
+            UserVerificationRequirement,
+        },
     },
     statecallback::StateCallback,
     Pin, StatusPinUv, StatusUpdate,
@@ -48,6 +51,13 @@ fn main() {
     opts.optflag("s", "hmac_secret", "With hmac-secret");
     opts.optflag("h", "help", "print this help menu");
     opts.optflag("f", "fallback", "Use CTAP1 fallback implementation");
+    opts.optopt(
+        "u",
+        "uv",
+        "User verification requirement (required, preferred, discouraged). Default is \"preferred\".",
+        "UV",
+    );
+
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!("{}", f.to_string()),
@@ -72,6 +82,21 @@ fn main() {
         }
         Err(e) => {
             println!("{e}");
+            print_usage(&program, opts);
+            return;
+        }
+    };
+
+    let user_verification_req = match matches.opt_get_default::<UserVerificationRequirement>(
+        "uv",
+        UserVerificationRequirement::Preferred,
+    ) {
+        Ok(uv) => {
+            println!("User verification requirement: {uv:?}");
+            uv
+        }
+        Err(e) => {
+            println!("Unknown user verification mode: {e}");
             print_usage(&program, opts);
             return;
         }
@@ -181,7 +206,7 @@ fn main() {
             ],
             transports: vec![Transport::USB, Transport::NFC],
         }],
-        user_verification_req: UserVerificationRequirement::Preferred,
+        user_verification_req,
         resident_key_req: ResidentKeyRequirement::Discouraged,
         extensions: AuthenticationExtensionsClientInputs {
             cred_props: Some(true),
@@ -212,6 +237,20 @@ fn main() {
             .expect("Problem receiving, unable to continue");
         match register_result {
             Ok(a) => {
+                println!("Register result: {a:?}");
+
+                let uv = a
+                    .att_obj
+                    .auth_data
+                    .flags
+                    .contains(AuthenticatorDataFlags::USER_VERIFIED);
+                if user_verification_req == UserVerificationRequirement::Required && !uv {
+                    panic!("User verification is required, but the authenticator did not set the UV flag (WebAuthn-3 §7.1, step 16)");
+                }
+                if uv {
+                    println!("User verified!");
+                }
+
                 println!("Ok!");
                 attestation_object = a;
                 break;
@@ -219,8 +258,6 @@ fn main() {
             Err(e) => panic!("Registration failed: {:?}", e),
         };
     }
-
-    println!("Register result: {:?}", &attestation_object);
 
     println!();
     println!("*********************************************************************");
@@ -242,7 +279,7 @@ fn main() {
         origin: format!("https://{rp_id}"),
         relying_party_id: rp_id,
         allow_list,
-        user_verification_req: UserVerificationRequirement::Preferred,
+        user_verification_req,
         user_presence_req: true,
         extensions: AuthenticationExtensionsClientInputs {
             app_id: using_app_id.then(|| app_id.clone()),
@@ -270,6 +307,19 @@ fn main() {
         match sign_result {
             Ok(assertion_object) => {
                 println!("Assertion Object: {assertion_object:?}");
+
+                let uv = assertion_object
+                    .assertion
+                    .auth_data
+                    .flags
+                    .contains(AuthenticatorDataFlags::USER_VERIFIED);
+                if user_verification_req == UserVerificationRequirement::Required && !uv {
+                    panic!("User verification is required, but the authenticator did not set the UV flag (WebAuthn-3 §7.2, step 17)");
+                }
+                if uv {
+                    println!("User verified!");
+                }
+
                 if using_app_id {
                     println!(
                         "Used AppID: {}",

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -12,6 +12,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::convert::{Into, TryFrom};
 use std::fmt;
+use std::str::FromStr;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct RpIdHash(pub [u8; 32]);
@@ -300,6 +301,20 @@ pub enum UserVerificationRequirement {
     Discouraged,
     Preferred,
     Required,
+}
+
+impl FromStr for UserVerificationRequirement {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // https://www.w3.org/TR/webauthn-3/#enumdef-userverificationrequirement
+        match s {
+            "required" => Ok(Self::Required),
+            "preferred" => Ok(Self::Preferred),
+            "discouraged" => Ok(Self::Discouraged),
+            s => Err(s.to_string()),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
Currently, the `ctap2` example always uses `uv = preferred`, and can't test the other options without changing the code.

The `ctap2_discoverable_creds` example always uses `uv = required`, but that uses resident keys, which risks bricking CTAP 2.0-only authenticators[^1]. I haven't touched that at all.

[^1]: Resident keys require storage space, which is extremely limited on hardware authenticators (generally less than 10 slots with undefined size limits). CTAP 2.0 supports _adding_ resident keys, but only CTAP 2.1 can manage and _remove_ them individually. Therefore, the only way to remove a resident key on a CTAP 2.0-only authenticator is with a factory reset, which destroys _all_ key material.

This change adds a `--uv` flag to the `ctap2` example, which defaults to `preferred` (ie: current behaviour).

While we're here, this also makes the `ctap2` example check [the `UV` bit of the authenticator's response](https://www.w3.org/TR/webauthn-3/#authdata-flags-uv). When `uv = required`, the example will now reject [registration](https://www.w3.org/TR/webauthn-3/#ref-for-user-verification%E2%91%A3%E2%91%A5) and [authentication](https://www.w3.org/TR/webauthn-3/#ref-for-user-verification%E2%91%A3%E2%91%A6) responses with the `UV` bit unset, [like an RP needs to do](https://unit42.paloaltonetworks.com/passwordless-authentication-security-risks/#section4SubHeading1).

This _doesn't_ set the CredProtect extension or anything like that.

This makes it easy _and safe_ to demonstrate #371, and that it'd be fixed by #370, but this PR is really an enhancement rather than a bugfix.

This also lets the `ctap2` example demonstrate self-contained multi-factor authentication _without_ requiring resident keys.
